### PR TITLE
Add landing page sections with contact form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+contacts.log

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Atendimento Jurídico | Cliente</title>
+  <title>Escritório de Advocacia</title>
   <link rel="stylesheet" href="/style.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <meta name="description" content="Fale por vídeo diretamente com seu advogado.">
@@ -19,6 +19,9 @@
         </div>
       </div>
       <div class="actions">
+        <a class="secondary" href="#about">Sobre</a>
+        <a class="secondary" href="#services">Atuação</a>
+        <a class="secondary" href="#contact">Contato</a>
         <a class="secondary" href="/lawyer.html" title="Área do Advogado">Área do Advogado</a>
       </div>
     </div>
@@ -48,6 +51,32 @@
       </div>
     </div>
 
+    <section id="about" class="panel" style="margin-top:14px;">
+      <h2 style="margin-top:0;">Sobre o Escritório</h2>
+      <p style="color: var(--muted);">Atendimento especializado e comprometido com a defesa dos seus direitos.</p>
+    </section>
+
+    <section id="services" class="panel" style="margin-top:14px;">
+      <h2 style="margin-top:0;">Áreas de Atuação</h2>
+      <ul style="margin:0; padding-left:20px;">
+        <li>Cível</li>
+        <li>Trabalhista</li>
+        <li>Família e Sucessões</li>
+      </ul>
+    </section>
+
+    <section id="contact" class="panel" style="margin-top:14px;">
+      <h2 style="margin-top:0;">Contato</h2>
+      <p style="color: var(--muted);">Envie uma mensagem ou inicie uma chamada de vídeo.</p>
+      <form id="contactForm" class="contact-form">
+        <input type="text" name="name" placeholder="Seu nome" required />
+        <input type="email" name="email" placeholder="Seu e-mail" required />
+        <textarea name="message" rows="4" placeholder="Mensagem" required></textarea>
+        <button type="submit" class="primary">Enviar mensagem</button>
+      </form>
+      <div id="contactStatus" class="footer"></div>
+    </section>
+
     <div class="footer">
       Conexão segura via WebRTC. Use Chrome/Edge/Firefox atualizados.
     </div>
@@ -55,5 +84,6 @@
 
   <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="/client.js"></script>
+  <script type="module" src="/site.js"></script>
 </body>
 </html>

--- a/public/site.js
+++ b/public/site.js
@@ -1,0 +1,25 @@
+const form = document.getElementById('contactForm');
+const statusEl = document.getElementById('contactStatus');
+
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(form).entries());
+    statusEl.textContent = 'Enviando...';
+    try {
+      const resp = await fetch('/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (resp.ok) {
+        form.reset();
+        statusEl.textContent = 'Mensagem enviada com sucesso!';
+      } else {
+        statusEl.textContent = 'Erro ao enviar mensagem.';
+      }
+    } catch (err) {
+      statusEl.textContent = 'Erro ao enviar mensagem.';
+    }
+  });
+}

--- a/public/style.css
+++ b/public/style.css
@@ -9,6 +9,10 @@
 
 * { box-sizing: border-box; }
 html, body { height: 100%; }
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
@@ -84,6 +88,14 @@ button.primary {
   cursor: pointer;
 }
 
+button {
+  transition: filter 0.2s ease;
+}
+
+button:hover {
+  filter: brightness(1.1);
+}
+
 button.secondary {
   background: transparent;
   border: 1px solid rgba(148, 163, 184, 0.4);
@@ -149,6 +161,25 @@ button.danger { background: #ef4444; color: white; }
   margin-top: 18px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.contact-form input,
+.contact-form textarea {
+  background: #0b1224;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 8px;
+  padding: 10px;
+  color: var(--text);
+}
+
+.contact-form textarea {
+  resize: vertical;
 }
 
 @media (max-width: 900px) {

--- a/server.js
+++ b/server.js
@@ -34,6 +34,19 @@ const io = new Server(server, {
 
 // Servir arquivos estáticos
 app.use(express.static('public'));
+app.use(express.json());
+
+app.post('/contact', (req, res) => {
+  const { name, email, message } = req.body || {};
+  if (!name || !email || !message) {
+    return res.status(400).json({ ok: false });
+  }
+  const log = `[${new Date().toISOString()}] ${name} <${email}>: ${message}\n`;
+  fs.appendFile(path.join(__dirname, 'contacts.log'), log, (err) => {
+    if (err) console.error('Erro ao salvar contato:', err);
+  });
+  res.json({ ok: true });
+});
 
 let lawyerSocket = null; // socket do advogado
 let busyWithClientId = null; // se estiver em ligação, guarda o id do cliente


### PR DESCRIPTION
## Summary
- Introduce About, Services and Contact sections on the public site
- Add contact form with server-side logging
- Enhance styling with smooth scroll and button hover effects

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a9087414b8832db0f9d7d9b90d46d4