### PR TITLE
Add elegant landing page with direct call section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,16 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Atendimento Jurídico | Cliente</title>
-  <link rel="stylesheet" href="/style.css" />
+  <title>Escritório de Advocacia</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <meta name="description" content="Fale por vídeo diretamente com seu advogado.">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css" />
+  <meta name="description" content="Atendimento jurídico moderno com contato direto ao advogado.">
 </head>
 <body>
-  <div class="container">
-    <div class="header">
+  <header class="site-header">
+    <div class="container header">
       <div class="brand">
         <svg width="28" height="28" viewBox="0 0 24 24" fill="#22c55e" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L1 21h22L12 2zm0 3.84L19.53 19H4.47L12 5.84zM11 10v5h2v-5h-2zm0 6v2h2v-2h-2z"/></svg>
         <div>
@@ -18,40 +20,85 @@
           <div class="badge" id="statusBadge">Carregando status...</div>
         </div>
       </div>
-      <div class="actions">
+      <nav class="nav-links">
+        <a href="#sobre">Sobre</a>
+        <a href="#areas">Áreas</a>
+        <a href="#contato">Contato</a>
         <a class="secondary" href="/lawyer.html" title="Área do Advogado">Área do Advogado</a>
-      </div>
+      </nav>
     </div>
+  </header>
 
-    <div class="panel hero" style="margin-top:14px;">
-      <div>
-        <h1 style="margin:0 0 8px 0; font-size:28px;">Fale com um advogado agora</h1>
-        <p style="margin:0 0 14px 0; color: var(--muted);">
-          Atendimento por chamada de vídeo e áudio, diretamente no seu navegador.
-        </p>
-        <div class="actions">
-          <button class="primary" id="callBtn">Ligar agora</button>
-          <button class="secondary" id="endBtn" disabled>Encerrar</button>
-          <button class="secondary" id="testBtn">Testar câmera/microfone</button>
-        </div>
-        <div id="info" class="footer">Aguardando...</div>
-      </div>
-      <div class="videos">
-        <div class="video-box">
-          <video id="remoteVideo" playsinline autoplay></video>
-          <div class="muted-note">Remoto</div>
-        </div>
-        <div class="video-box">
-          <video id="localVideo" playsinline autoplay muted></video>
-          <div class="muted-note">Você (mudo)</div>
-        </div>
-      </div>
+  <section class="hero-section">
+    <div class="container">
+      <h1>Defendendo seus direitos com excelência</h1>
+      <p>Atendimento jurídico moderno, humano e eficiente.</p>
+      <button class="primary" onclick="document.getElementById('contato').scrollIntoView({behavior:'smooth'})">Fale agora</button>
     </div>
+  </section>
 
-    <div class="footer">
-      Conexão segura via WebRTC. Use Chrome/Edge/Firefox atualizados.
+  <section id="sobre" class="about-section">
+    <div class="container">
+      <h2>Sobre</h2>
+      <div class="panel">
+        <p>Atuamos com dedicação e transparência para garantir a melhor defesa dos seus interesses. Utilizamos tecnologia de ponta para agilizar seu atendimento.</p>
+      </div>
     </div>
-  </div>
+  </section>
+
+  <section id="areas" class="areas-section">
+    <div class="container">
+      <h2>Áreas de Atuação</h2>
+      <div class="areas-grid">
+        <div class="area-card">
+          <div class="icon">⚖️</div>
+          <h3>Direito Civil</h3>
+          <p>Conflitos entre pessoas e instituições.</p>
+        </div>
+        <div class="area-card">
+          <div class="icon">💼</div>
+          <h3>Direito Trabalhista</h3>
+          <p>Defesa dos seus direitos no ambiente de trabalho.</p>
+        </div>
+        <div class="area-card">
+          <div class="icon">🏢</div>
+          <h3>Direito Empresarial</h3>
+          <p>Consultoria para empresas e empreendedores.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="contato" class="contact-section">
+    <div class="container">
+      <h2>Contato</h2>
+      <div class="panel hero">
+        <div>
+          <p style="margin:0 0 14px 0; color: var(--muted);">Fale por chamada de vídeo e áudio diretamente com o advogado.</p>
+          <div class="actions">
+            <button class="primary" id="callBtn">Ligar agora</button>
+            <button class="secondary" id="endBtn" disabled>Encerrar</button>
+            <button class="secondary" id="testBtn">Testar câmera/microfone</button>
+          </div>
+          <div id="info" class="footer">Aguardando...</div>
+        </div>
+        <div class="videos">
+          <div class="video-box">
+            <video id="remoteVideo" playsinline autoplay></video>
+            <div class="muted-note">Remoto</div>
+          </div>
+          <div class="video-box">
+            <video id="localVideo" playsinline autoplay muted></video>
+            <div class="muted-note">Você (mudo)</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">© 2024 Escritório de Advocacia. Todos os direitos reservados.</div>
+  </footer>
 
   <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="/client.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -11,7 +11,7 @@
 html, body { height: 100%; }
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: 'Poppins', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
   background: linear-gradient(120deg, #0f172a 0%, #0b1224 100%);
   color: var(--text);
 }
@@ -82,6 +82,7 @@ button.primary {
   padding: 12px 16px;
   font-weight: 600;
   cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 button.secondary {
@@ -91,9 +92,20 @@ button.secondary {
   border-radius: 10px;
   padding: 12px 16px;
   cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
 }
 
 button.danger { background: #ef4444; color: white; }
+
+button.primary:hover {
+  box-shadow: 0 4px 12px rgba(34, 197, 94, 0.35);
+  transform: translateY(-2px);
+}
+
+button.secondary:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
 
 .videos {
   display: grid;
@@ -156,3 +168,110 @@ button.danger { background: #ef4444; color: white; }
   .videos { grid-template-columns: 1fr; }
 }
 
+body { scroll-behavior: smooth; }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  z-index: 50;
+}
+
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  margin-left: 16px;
+  transition: color 0.3s;
+}
+
+.nav-links a:hover { color: var(--accent); }
+
+section h2 {
+  font-size: 32px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 40px;
+  position: relative;
+}
+
+section h2::after {
+  content: "";
+  position: absolute;
+  width: 80px;
+  height: 4px;
+  background: var(--accent);
+  left: 50%;
+  bottom: -12px;
+  transform: translateX(-50%);
+  border-radius: 2px;
+}
+
+.hero-section {
+  text-align: center;
+  padding: 100px 16px;
+  background: linear-gradient(135deg, #0b1224 0%, #141e31 100%);
+  animation: fadeIn 1s ease forwards;
+}
+
+.hero-section h1 { font-size: 42px; margin-bottom: 16px; }
+.hero-section p { color: var(--muted); margin-bottom: 24px; }
+
+.about-section,
+.areas-section,
+.contact-section {
+  padding: 80px 16px;
+}
+
+.areas-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+}
+
+.area-card {
+  flex: 1 1 260px;
+  background: rgba(17, 24, 39, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 12px;
+  padding: 24px 20px;
+  text-align: center;
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.area-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--accent);
+}
+
+.area-card .icon {
+  font-size: 32px;
+  margin-bottom: 12px;
+}
+
+.area-card h3 {
+  margin: 0 0 8px;
+  font-size: 20px;
+  color: var(--accent);
+}
+
+.area-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.site-footer {
+  background: #0b1224;
+  text-align: center;
+  padding: 32px 16px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- Integrate Google Fonts Poppins and keep dark green palette for refined typography
- Wrap about text in translucent panel and add icon cards for practice areas
- Style section headings and buttons with accent underlines and hover transitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(installs express and socket.io)*
- `node server.js` (prints startup messages)


------
https://chatgpt.com/codex/tasks/task_e_68a9087414b8832db0f9d7d9b90d46d4