### PR TITLE
Add online-only contact options and chat-enabled footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/background.js
+++ b/public/background.js
@@ -1,0 +1,14 @@
+(() => {
+  const root = document.documentElement;
+  function update(e) {
+    const x = e.clientX ?? (e.touches && e.touches[0].clientX);
+    const y = e.clientY ?? (e.touches && e.touches[0].clientY);
+    if (x != null && y != null) {
+      root.style.setProperty('--bg-x', (x / window.innerWidth) * 100 + '%');
+      root.style.setProperty('--bg-y', (y / window.innerHeight) * 100 + '%');
+    }
+  }
+  window.addEventListener('mousemove', update);
+  window.addEventListener('touchmove', update);
+  window.addEventListener('touchstart', update);
+})();

--- a/public/client.js
+++ b/public/client.js
@@ -7,6 +7,13 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const endBtn = document.getElementById('endBtn');
   const localVideo = document.getElementById('localVideo');
   const remoteVideo = document.getElementById('remoteVideo');
+  const callModeSel = document.getElementById('callMode');
+  const videoArea = document.getElementById('videoArea');
+  const contactSection = document.getElementById('contato');
+  const navContato = document.getElementById('navContato');
+  const chatMessages = document.getElementById('chatMessages');
+  const chatForm = document.getElementById('chatForm');
+  const chatInput = document.getElementById('chatInput');
 
   const socket = io();
   socket.emit('identify', { role: 'client' });
@@ -22,14 +29,20 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
       statusBadge.className = 'badge online';
       statusBadge.textContent = 'Advogado online';
       callBtn.disabled = false;
+      contactSection.style.display = 'block';
+      navContato.style.display = 'inline';
     } else if (online && busy) {
       statusBadge.className = 'badge busy';
       statusBadge.textContent = 'Advogado em chamada';
       callBtn.disabled = true;
+      contactSection.style.display = 'block';
+      navContato.style.display = 'inline';
     } else {
       statusBadge.className = 'badge';
       statusBadge.textContent = 'Advogado offline';
       callBtn.disabled = true;
+      contactSection.style.display = 'none';
+      navContato.style.display = 'none';
     }
   }
 
@@ -38,7 +51,7 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   callBtn.addEventListener('click', async () => {
     callBtn.disabled = true;
     setInfo('Chamando o advogado...');
-    socket.emit('request-call');
+    socket.emit('request-call', { mode: callModeSel.value });
   });
 
   endBtn.addEventListener('click', async () => {
@@ -54,11 +67,19 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
 
   socket.on('call-accepted', async ({ lawyerId }) => {
     currentLawyerId = lawyerId;
+    const mode = callModeSel.value;
+    if (mode === 'audio') videoArea.style.display = 'none'; else videoArea.style.display = 'grid';
     setInfo('Chamada aceita. Iniciando mídia...');
     try {
-      const res = await getMediaWithFallback();
+      let res;
+      if (mode === 'audio') {
+        const s = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+        res = { stream: s };
+      } else {
+        res = await getMediaWithFallback();
+      }
       localStream = res.stream;
-      localVideo.srcObject = localStream;
+      if (mode !== 'audio') localVideo.srcObject = localStream;
 
       pc = createPeerConnection(lawyerId);
       localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
@@ -128,6 +149,7 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     }
     localVideo.srcObject = null;
     remoteVideo.srcObject = null;
+    videoArea.style.display = 'grid';
     endBtn.disabled = true;
     callBtn.disabled = false;
     setInfo(message || 'Aguardando...');
@@ -156,5 +178,52 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   // Aviso de contexto inseguro
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
+  }
+
+  // Chat
+  if (chatForm) {
+    chatForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const msg = chatInput.value.trim();
+      if (!msg) return;
+      appendChat('Você: ' + msg);
+      socket.emit('chat-from-client', { message: msg });
+      chatInput.value = '';
+    });
+  }
+
+  socket.on('chat-from-lawyer', ({ message }) => {
+    appendChat('Advogado: ' + message);
+  });
+
+  function appendChat(text) {
+    if (!chatMessages) return;
+    const div = document.createElement('div');
+    div.textContent = text;
+    chatMessages.appendChild(div);
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+  }
+
+  // Formulário de contato
+  const contactForm = document.getElementById('contactForm');
+  if (contactForm) {
+    contactForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name = document.getElementById('name').value;
+      const email = document.getElementById('email').value;
+      const message = document.getElementById('message').value;
+      const status = document.getElementById('formStatus');
+      try {
+        const res = await fetch('/contact', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, email, message })
+        });
+        status.textContent = res.ok ? 'Mensagem enviada!' : 'Falha ao enviar.';
+        contactForm.reset();
+      } catch {
+        status.textContent = 'Erro ao enviar.';
+      }
+    });
   }
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,16 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Atendimento Jurídico | Cliente</title>
-  <link rel="stylesheet" href="/style.css" />
+  <title>Escritório de Advocacia</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <meta name="description" content="Fale por vídeo diretamente com seu advogado.">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css" />
+  <meta name="description" content="Atendimento jurídico moderno com contato direto ao advogado.">
 </head>
 <body>
-  <div class="container">
-    <div class="header">
+  <header class="site-header">
+    <div class="container header">
       <div class="brand">
         <svg width="28" height="28" viewBox="0 0 24 24" fill="#22c55e" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L1 21h22L12 2zm0 3.84L19.53 19H4.47L12 5.84zM11 10v5h2v-5h-2zm0 6v2h2v-2h-2z"/></svg>
         <div>
@@ -18,42 +20,116 @@
           <div class="badge" id="statusBadge">Carregando status...</div>
         </div>
       </div>
-      <div class="actions">
+      <nav class="nav-links">
+        <a href="#contato" id="navContato" style="display:none">Contato</a>
+        <a href="#sobre">Sobre</a>
+        <a href="#areas">Áreas</a>
         <a class="secondary" href="/lawyer.html" title="Área do Advogado">Área do Advogado</a>
+      </nav>
+    </div>
+  </header>
+  <section id="contato" class="contact-section" style="display:none">
+    <div class="container">
+      <h2>Contato</h2>
+      <div class="contact-grid">
+        <div class="panel call-box">
+          <p style="margin:0 0 14px 0; color: var(--muted);">Fale por chamada de vídeo e áudio diretamente com o advogado.</p>
+          <div class="actions" style="margin-bottom:12px; align-items:center;">
+            <select id="callMode" class="call-mode">
+              <option value="av">Vídeo e áudio</option>
+              <option value="audio">Somente áudio</option>
+            </select>
+            <button class="primary" id="callBtn">Ligar agora</button>
+            <button class="secondary" id="endBtn" disabled>Encerrar</button>
+            <button class="secondary" id="testBtn">Testar câmera/microfone</button>
+          </div>
+          <div class="videos" id="videoArea">
+            <div class="video-box">
+              <video id="remoteVideo" playsinline autoplay></video>
+              <div class="muted-note">Remoto</div>
+            </div>
+            <div class="video-box">
+              <video id="localVideo" playsinline autoplay muted></video>
+              <div class="muted-note">Você (mudo)</div>
+            </div>
+          </div>
+          <div id="info" class="footer">Aguardando...</div>
+        </div>
+        <div class="panel chat-box">
+          <div id="chatMessages" class="chat-messages"></div>
+          <form id="chatForm" class="chat-form">
+            <input id="chatInput" type="text" placeholder="Digite sua mensagem" required>
+            <button class="primary" type="submit">Enviar</button>
+          </form>
+        </div>
       </div>
     </div>
+  </section>
 
-    <div class="panel hero" style="margin-top:14px;">
-      <div>
-        <h1 style="margin:0 0 8px 0; font-size:28px;">Fale com um advogado agora</h1>
-        <p style="margin:0 0 14px 0; color: var(--muted);">
-          Atendimento por chamada de vídeo e áudio, diretamente no seu navegador.
-        </p>
-        <div class="actions">
-          <button class="primary" id="callBtn">Ligar agora</button>
-          <button class="secondary" id="endBtn" disabled>Encerrar</button>
-          <button class="secondary" id="testBtn">Testar câmera/microfone</button>
-        </div>
-        <div id="info" class="footer">Aguardando...</div>
-      </div>
-      <div class="videos">
-        <div class="video-box">
-          <video id="remoteVideo" playsinline autoplay></video>
-          <div class="muted-note">Remoto</div>
-        </div>
-        <div class="video-box">
-          <video id="localVideo" playsinline autoplay muted></video>
-          <div class="muted-note">Você (mudo)</div>
-        </div>
-      </div>
+  <section class="hero-section">
+    <div class="container">
+      <h1>Defendendo seus direitos com excelência</h1>
+      <p>Atendimento jurídico moderno, humano e eficiente.</p>
+      <button class="primary" onclick="document.getElementById('contato').scrollIntoView({behavior:'smooth'})">Fale agora</button>
     </div>
+  </section>
 
-    <div class="footer">
-      Conexão segura via WebRTC. Use Chrome/Edge/Firefox atualizados.
+  <section id="sobre" class="about-section">
+    <div class="container">
+      <h2>Sobre</h2>
+      <p>Atuamos com dedicação e transparência para garantir a melhor defesa dos seus interesses. Utilizamos tecnologia de ponta para agilizar seu atendimento.</p>
     </div>
-  </div>
+  </section>
+
+  <section id="areas" class="areas-section">
+    <div class="container">
+      <h2>Áreas de Atuação</h2>
+      <div class="areas-grid">
+        <div class="area-card">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0 0 12 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 0 1-2.031.352 5.988 5.988 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971Zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 0 1-2.031.352 5.989 5.989 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L5.25 4.971Z"/></svg>
+          <span>Direito Civil</span>
+        </div>
+        <div class="area-card">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0M12 12.75h.008v.008H12v-.008Z"/></svg>
+          <span>Direito Trabalhista</span>
+        </div>
+        <div class="area-card">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008Zm0 3h.008v.008h-.008v-.008Zm0 3h.008v.008h-.008v-.008Z"/></svg>
+          <span>Direito Empresarial</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="contato-form" class="form-section">
+    <div class="container">
+      <h2>Envie uma Mensagem</h2>
+      <form id="contactForm" class="contact-form">
+        <input type="text" id="name" placeholder="Seu nome" required>
+        <input type="email" id="email" placeholder="Seu e-mail" required>
+        <textarea id="message" rows="5" placeholder="Sua mensagem" required></textarea>
+        <button type="submit" class="primary">Enviar</button>
+        <div id="formStatus" class="form-status"></div>
+      </form>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>© 2024 Escritório de Advocacia. Todos os direitos reservados.</div>
+      <div class="social-links">
+        <a href="#" aria-label="LinkedIn" class="social-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M4.98 3.5C4.98 4.88 3.86 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8.5h4V24h-4V8.5zm7.5 0h3.8v2.1h.05c.53-1 1.82-2.1 3.74-2.1 4 0 4.74 2.63 4.74 6v9.5h-4v-8.4c0-2-.04-4.5-2.75-4.5-2.76 0-3.18 2.15-3.18 4.37V24h-4V8.5z"/></svg>
+        </a>
+        <a href="#" aria-label="Instagram" class="social-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M7.75 2h8.5A5.75 5.75 0 0 1 22 7.75v8.5A5.75 5.75 0 0 1 16.25 22h-8.5A5.75 5.75 0 0 1 2 16.25v-8.5A5.75 5.75 0 0 1 7.75 2Zm0 1.5A4.25 4.25 0 0 0 3.5 7.75v8.5A4.25 4.25 0 0 0 7.75 20.5h8.5A4.25 4.25 0 0 0 20.5 16.25v-8.5A4.25 4.25 0 0 0 16.25 3.5h-8.5ZM12 7a5 5 0 1 1 0 10 5 5 0 0 1 0-10Zm0 1.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Zm5.5-.88a1.13 1.13 0 1 1-2.26 0 1.13 1.13 0 0 1 2.26 0Z"/></svg>
+        </a>
+      </div>
+    </div>
+  </footer>
 
   <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="/client.js"></script>
+  <script src="/background.js"></script>
 </body>
 </html>

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -37,6 +37,13 @@
         <button id="hangupBtn" class="danger" disabled>Encerrar chamada</button>
         <button id="testBtn" class="secondary">Testar câmera/microfone</button>
       </div>
+      <div class="chat-box" style="margin-top:12px;">
+        <div id="chatMessages" class="chat-messages"></div>
+        <form id="chatForm" class="chat-form">
+          <input id="chatInput" type="text" placeholder="Digite sua mensagem" required>
+          <button class="primary" type="submit">Enviar</button>
+        </form>
+      </div>
       <div id="info" class="footer">Aguardando chamadas...</div>
     </div>
   </div>

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -8,6 +8,10 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const acceptBtn = document.getElementById('acceptBtn');
   const rejectBtn = document.getElementById('rejectBtn');
   const hangupBtn = document.getElementById('hangupBtn');
+  const videoArea = document.querySelector('.videos');
+  const chatMessages = document.getElementById('chatMessages');
+  const chatForm = document.getElementById('chatForm');
+  const chatInput = document.getElementById('chatInput');
 
   const socket = io();
   socket.emit('identify', { role: 'lawyer' });
@@ -15,12 +19,15 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   let pc = null; // RTCPeerConnection
   let localStream = null;
   let currentClientId = null;
+  let currentMode = 'av';
 
   function setInfo(text) { info.textContent = text; }
 
   let pendingClientId = null;
-  socket.on('incoming-call', ({ clientId }) => {
+  socket.on('incoming-call', ({ clientId, mode }) => {
     pendingClientId = clientId;
+    currentMode = mode || 'av';
+    incoming.querySelector('.modal').querySelector('div').textContent = mode === 'audio' ? 'Chamada de voz' : 'Chamada de vídeo';
     incoming.style.display = 'flex';
   });
 
@@ -37,9 +44,17 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     incoming.style.display = 'none';
     setInfo('Preparando mídia...');
     try {
-      const res = await getMediaWithFallback();
+      let res;
+      if (currentMode === 'audio') {
+        const s = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+        res = { stream: s };
+        videoArea.style.display = 'none';
+      } else {
+        res = await getMediaWithFallback();
+        videoArea.style.display = 'grid';
+      }
       localStream = res.stream;
-      localVideo.srcObject = localStream;
+      if (currentMode !== 'audio') localVideo.srcObject = localStream;
       pc = createPeerConnection(currentClientId);
       localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
       socket.emit('accept-call', { clientId: currentClientId });
@@ -111,6 +126,7 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     }
     localVideo.srcObject = null;
     remoteVideo.srcObject = null;
+    videoArea.style.display = 'grid';
     hangupBtn.disabled = true;
     currentClientId = null;
     setInfo(message || 'Aguardando chamadas...');
@@ -139,5 +155,31 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   // Aviso de contexto inseguro
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
+  }
+
+  // Chat
+  if (chatForm) {
+    chatForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const msg = chatInput.value.trim();
+      if (!msg || !currentClientId) return;
+      appendChat('Você: ' + msg);
+      socket.emit('chat-from-lawyer', { clientId: currentClientId, message: msg });
+      chatInput.value = '';
+    });
+  }
+
+  socket.on('chat-from-client', ({ clientId, message }) => {
+    if (!currentClientId) currentClientId = clientId;
+    if (clientId !== currentClientId) return;
+    appendChat('Cliente: ' + message);
+  });
+
+  function appendChat(text) {
+    if (!chatMessages) return;
+    const div = document.createElement('div');
+    div.textContent = text;
+    chatMessages.appendChild(div);
+    chatMessages.scrollTop = chatMessages.scrollHeight;
   }
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -5,21 +5,58 @@
   --accent-2: #ef4444; /* red-500 */
   --text: #e5e7eb; /* gray-200 */
   --muted: #94a3b8; /* slate-400 */
+  --bg-x: 50%;
+  --bg-y: 50%;
 }
 
 * { box-sizing: border-box; }
 html, body { height: 100%; }
 body {
-  margin: 0;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  background: linear-gradient(120deg, #0f172a 0%, #0b1224 100%);
-  color: var(--text);
+    margin: 0;
+    font-family: 'Poppins', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+    background: linear-gradient(120deg, #0f172a 0%, #0b1224 100%);
+    color: var(--text);
+    line-height: 1.6;
+    position: relative;
+    z-index: 0;
+  }
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at var(--bg-x) var(--bg-y), rgba(34,197,94,0.15), transparent 60%);
+  pointer-events: none;
+  z-index: -1;
+  transition: background 0.15s;
 }
 
 .container {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 16px;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 16px;
+  }
+
+h1, h2, h3 {
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+h2 {
+  font-size: 32px;
+  margin-bottom: 24px;
+  text-align: center;
+  position: relative;
+}
+
+h2::after {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 999px;
+  margin: 8px auto 0;
 }
 
 .header {
@@ -75,22 +112,35 @@ body {
 }
 
 button.primary {
-  background: linear-gradient(90deg, #22c55e, #16a34a);
-  color: #052e16;
-  border: none;
+    background: linear-gradient(90deg, #22c55e, #16a34a);
+    color: #052e16;
+    border: none;
   border-radius: 10px;
   padding: 12px 16px;
   font-weight: 600;
-  cursor: pointer;
-}
+    cursor: pointer;
+    transition: filter 0.3s, transform 0.2s;
+  }
 
 button.secondary {
-  background: transparent;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  color: var(--text);
-  border-radius: 10px;
-  padding: 12px 16px;
-  cursor: pointer;
+    background: transparent;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 12px 16px;
+    cursor: pointer;
+    transition: color 0.3s, border-color 0.3s, transform 0.2s;
+  }
+
+button.primary:hover {
+  filter: brightness(1.1);
+  transform: translateY(-2px);
+}
+
+button.secondary:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  transform: translateY(-2px);
 }
 
 button.danger { background: #ef4444; color: white; }
@@ -156,3 +206,196 @@ button.danger { background: #ef4444; color: white; }
   .videos { grid-template-columns: 1fr; }
 }
 
+body { scroll-behavior: smooth; }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  z-index: 50;
+}
+
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  margin-left: 16px;
+  transition: color 0.3s;
+}
+
+.nav-links a:hover { color: var(--accent); }
+
+.hero-section {
+  text-align: center;
+  padding: 100px 16px;
+  background: linear-gradient(135deg, #0b1224 0%, #141e31 100%);
+  animation: fadeIn 1s ease forwards;
+}
+
+.hero-section h1 { font-size: 42px; margin-bottom: 16px; }
+.hero-section p { color: var(--muted); margin-bottom: 24px; }
+
+.about-section,
+.areas-section,
+.contact-section {
+  padding: 80px 16px;
+}
+
+.contact-section {
+  padding: 40px 16px;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.call-box .videos {
+  margin-top: 12px;
+}
+
+.call-mode {
+  padding: 10px;
+  border-radius: 8px;
+  background: #0b1224;
+  border: 1px solid rgba(148,163,184,0.4);
+  color: var(--text);
+}
+
+.chat-box {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  background: rgba(15,23,42,0.5);
+  border: 1px solid rgba(148,163,184,0.15);
+  border-radius: 10px;
+  padding: 8px;
+  margin-bottom: 12px;
+}
+
+.chat-messages div {
+  margin-bottom: 6px;
+  font-size: 14px;
+}
+
+.chat-form {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-form input {
+  flex: 1;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(148,163,184,0.4);
+  background: #0b1224;
+  color: var(--text);
+}
+
+.chat-form button { flex-shrink: 0; }
+
+.areas-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+  }
+
+.area-card {
+    flex: 1 1 200px;
+    background: rgba(17, 24, 39, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    border-radius: 12px;
+    padding: 24px 16px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    font-weight: 500;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    transition: transform 0.3s, box-shadow 0.3s;
+  }
+
+.area-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.3);
+}
+
+.area-card svg {
+  width: 40px;
+  height: 40px;
+  stroke: var(--accent);
+}
+
+.site-footer {
+  background: #0b1224;
+  text-align: center;
+  padding: 32px 16px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.footer-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.social-links {
+  display: flex;
+  gap: 16px;
+}
+
+.social-icon svg {
+  width: 24px;
+  height: 24px;
+  fill: var(--text);
+  transition: fill 0.3s;
+}
+
+.social-icon:hover svg { fill: var(--accent); }
+
+.form-section {
+  padding: 80px 16px;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(148,163,184,0.4);
+  background: rgba(15,23,42,0.6);
+  color: var(--text);
+}
+
+.form-status {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+@media (max-width: 900px) {
+  .contact-grid { grid-template-columns: 1fr; }
+  .footer-grid { text-align: center; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { Server } = require('socket.io');
 
 const app = express();
+app.use(express.json());
 
 // Detectar certificados locais para HTTPS
 let server;
@@ -63,7 +64,7 @@ io.on('connection', (socket) => {
   });
 
   // Cliente pede para iniciar uma chamada
-  socket.on('request-call', () => {
+  socket.on('request-call', ({ mode } = {}) => {
     if (!lawyerSocket) {
       socket.emit('call-unavailable', { reason: 'offline' });
       return;
@@ -74,7 +75,7 @@ io.on('connection', (socket) => {
     }
     busyWithClientId = socket.id;
     broadcastLawyerStatus();
-    lawyerSocket.emit('incoming-call', { clientId: socket.id });
+    lawyerSocket.emit('incoming-call', { clientId: socket.id, mode });
   });
 
   // Advogado aceita a chamada
@@ -114,6 +115,16 @@ io.on('connection', (socket) => {
     if (targetId && candidate) io.to(targetId).emit('webrtc-ice-candidate', { from: socket.id, candidate });
   });
 
+  // Chat texto simples
+  socket.on('chat-from-client', ({ message }) => {
+    if (lawyerSocket && message) {
+      lawyerSocket.emit('chat-from-client', { clientId: socket.id, message });
+    }
+  });
+  socket.on('chat-from-lawyer', ({ clientId, message }) => {
+    if (clientId && message) io.to(clientId).emit('chat-from-lawyer', { message });
+  });
+
   socket.on('disconnect', () => {
     // Se o advogado desconectar
     if (lawyerSocket && socket.id === lawyerSocket.id) {
@@ -133,6 +144,12 @@ io.on('connection', (socket) => {
       broadcastLawyerStatus();
     }
   });
+});
+
+// Endpoint simples para formulário de contato
+app.post('/contact', (req, res) => {
+  console.log('Contato recebido:', req.body);
+  res.json({ ok: true });
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- Hide call interface unless lawyer is online and allow selecting video+audio or audio-only calls
- Introduce real-time text chat plus a traditional contact form with social links in the footer
- Style contact area with a two-column layout and responsive design tweaks

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68a9087414b8832db0f9d7d9b90d46d4