### PR TITLE
Add online indicator and polish contact modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/background.js
+++ b/public/background.js
@@ -1,0 +1,14 @@
+(() => {
+  const root = document.documentElement;
+  function update(e) {
+    const x = e.clientX ?? (e.touches && e.touches[0].clientX);
+    const y = e.clientY ?? (e.touches && e.touches[0].clientY);
+    if (x != null && y != null) {
+      root.style.setProperty('--bg-x', (x / window.innerWidth) * 100 + '%');
+      root.style.setProperty('--bg-y', (y / window.innerHeight) * 100 + '%');
+    }
+  }
+  window.addEventListener('mousemove', update);
+  window.addEventListener('touchmove', update);
+  window.addEventListener('touchstart', update);
+})();

--- a/public/client.js
+++ b/public/client.js
@@ -7,6 +7,23 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const endBtn = document.getElementById('endBtn');
   const localVideo = document.getElementById('localVideo');
   const remoteVideo = document.getElementById('remoteVideo');
+  const callInterface = document.getElementById('callInterface');
+  const contactSection = document.getElementById('contato');
+  const contactLink = document.getElementById('contactLink');
+  const videoContainer = document.getElementById('videoContainer');
+  const chatContainer = document.getElementById('chatContainer');
+  const messages = document.getElementById('messages');
+  const chatInput = document.getElementById('chatInput');
+  const sendBtn = document.getElementById('sendBtn');
+  const testBtn = document.getElementById('testBtn');
+  const modeRadios = document.querySelectorAll('input[name="mode"]');
+  const modeOptions = document.querySelector('.mode-options');
+  const actions = document.querySelector('.actions');
+  const backBtn = document.getElementById('backBtn');
+
+  let currentMode = 'video';
+  let lastOnline = false;
+  let lastBusy = false;
 
   const socket = io();
   socket.emit('identify', { role: 'client' });
@@ -18,27 +35,83 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   function setInfo(text) { info.textContent = text; }
 
   function setStatusOnline(online, busy) {
+    lastOnline = online;
+    lastBusy = busy;
     if (online && !busy) {
       statusBadge.className = 'badge online';
       statusBadge.textContent = 'Advogado online';
-      callBtn.disabled = false;
     } else if (online && busy) {
       statusBadge.className = 'badge busy';
       statusBadge.textContent = 'Advogado em chamada';
-      callBtn.disabled = true;
     } else {
-      statusBadge.className = 'badge';
+      statusBadge.className = 'badge offline';
       statusBadge.textContent = 'Advogado offline';
-      callBtn.disabled = true;
+    }
+    callBtn.disabled = !(online && !busy) || currentMode === 'chat';
+    if (online) {
+      callInterface.classList.remove('hidden');
+      contactSection.classList.remove('hidden');
+      contactLink.classList.remove('hidden');
+    } else {
+      callInterface.classList.add('hidden');
+      contactSection.classList.add('hidden');
+      contactLink.classList.add('hidden');
+    }
+    if (currentMode === 'chat') {
+      sendBtn.disabled = !online;
     }
   }
 
   socket.on('lawyer-status', ({ online, busy }) => setStatusOnline(online, busy));
 
+  modeRadios.forEach(r => r.addEventListener('change', () => {
+    currentMode = document.querySelector('input[name="mode"]:checked').value;
+    if (currentMode === 'chat') {
+      videoContainer.classList.add('hidden');
+      chatContainer.classList.remove('hidden');
+      callBtn.classList.add('hidden');
+      endBtn.classList.add('hidden');
+      testBtn.classList.add('hidden');
+      actions.classList.add('hidden');
+      modeOptions.classList.add('hidden');
+      setInfo('Converse por texto com o advogado.');
+      sendBtn.disabled = !lastOnline;
+    } else {
+      chatContainer.classList.add('hidden');
+      actions.classList.remove('hidden');
+      modeOptions.classList.remove('hidden');
+      callBtn.classList.remove('hidden');
+      endBtn.classList.remove('hidden');
+      testBtn.classList.remove('hidden');
+      videoContainer.classList.toggle('hidden', currentMode === 'audio');
+      callBtn.textContent = currentMode === 'audio' ? 'Ligar (áudio)' : 'Ligar agora';
+      setInfo('Aguardando...');
+      sendBtn.disabled = true;
+    }
+    callBtn.disabled = !(lastOnline && !lastBusy) || currentMode === 'chat';
+  }));
+
+  if (backBtn) {
+    backBtn.addEventListener('click', () => {
+      chatContainer.classList.add('hidden');
+      modeOptions.classList.remove('hidden');
+      actions.classList.remove('hidden');
+      currentMode = 'video';
+      document.querySelector('input[name="mode"][value="video"]').checked = true;
+      videoContainer.classList.remove('hidden');
+      callBtn.classList.remove('hidden');
+      endBtn.classList.remove('hidden');
+      testBtn.classList.remove('hidden');
+      setInfo('Aguardando...');
+      sendBtn.disabled = true;
+      callBtn.disabled = !(lastOnline && !lastBusy);
+    });
+  }
+
   callBtn.addEventListener('click', async () => {
     callBtn.disabled = true;
     setInfo('Chamando o advogado...');
-    socket.emit('request-call');
+    socket.emit('request-call', { mode: currentMode });
   });
 
   endBtn.addEventListener('click', async () => {
@@ -56,7 +129,7 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     currentLawyerId = lawyerId;
     setInfo('Chamada aceita. Iniciando mídia...');
     try {
-      const res = await getMediaWithFallback();
+      const res = await getMediaWithFallback(currentMode);
       localStream = res.stream;
       localVideo.srcObject = localStream;
 
@@ -133,12 +206,37 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     setInfo(message || 'Aguardando...');
   }
 
+  // Chat
+  function appendMessage(sender, text) {
+    const div = document.createElement('div');
+    div.textContent = `${sender}: ${text}`;
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  function sendChat() {
+    const msg = chatInput.value.trim();
+    if (!msg) return;
+    appendMessage('Você', msg);
+    socket.emit('chat-message', { message: msg });
+    chatInput.value = '';
+  }
+
+  sendBtn.addEventListener('click', sendChat);
+  chatInput.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); sendChat(); }
+  });
+
+  socket.on('chat-message', ({ from, message }) => {
+    const sender = from === 'lawyer' ? 'Advogado' : 'Cliente';
+    appendMessage(sender, message);
+  });
+
   // Teste manual de mídia
-  const testBtn = document.getElementById('testBtn');
   if (testBtn) {
     testBtn.addEventListener('click', async () => {
       try {
-        const res = await getMediaWithFallback();
+        const res = await getMediaWithFallback(currentMode);
         setInfo('Teste: ' + res.note);
         const tmp = res.stream;
         localVideo.srcObject = tmp;

--- a/public/index.html
+++ b/public/index.html
@@ -3,57 +3,131 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Atendimento Jurídico | Cliente</title>
-  <link rel="stylesheet" href="/style.css" />
+  <title>Escritório de Advocacia Online</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <meta name="description" content="Fale por vídeo diretamente com seu advogado.">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css" />
+  <meta name="description" content="Atendimento jurídico moderno com contato direto ao advogado.">
 </head>
 <body>
-  <div class="container">
-    <div class="header">
+  <header class="site-header">
+    <div class="container header">
       <div class="brand">
         <svg width="28" height="28" viewBox="0 0 24 24" fill="#22c55e" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L1 21h22L12 2zm0 3.84L19.53 19H4.47L12 5.84zM11 10v5h2v-5h-2zm0 6v2h2v-2h-2z"/></svg>
         <div>
-          <div style="font-weight:700;">Escritório de Advocacia</div>
+          <div style="font-weight:700;">Escritório de Advocacia Online</div>
           <div class="badge" id="statusBadge">Carregando status...</div>
         </div>
       </div>
-      <div class="actions">
+      <nav class="nav-links">
+        <a href="#contato" id="contactLink" class="hidden">Contato</a>
+        <a href="#sobre">Sobre</a>
+        <a href="#areas">Áreas</a>
         <a class="secondary" href="/lawyer.html" title="Área do Advogado">Área do Advogado</a>
+      </nav>
+    </div>
+  </header>
+  <section id="contato" class="contact-section hidden">
+    <div class="container">
+      <h2>Contato</h2>
+      <div id="callInterface" class="panel contact-panel hidden">
+        <div>
+          <p style="margin:0 0 14px 0; color: var(--muted);">Escolha como deseja falar com o advogado.</p>
+          <div class="mode-options">
+            <label><input type="radio" name="mode" value="video" checked>Vídeo + Áudio</label>
+            <label><input type="radio" name="mode" value="audio">Somente Áudio</label>
+            <label><input type="radio" name="mode" value="chat">Chat de Texto</label>
+          </div>
+          <div class="actions">
+            <button class="primary" id="callBtn">Ligar agora</button>
+            <button class="secondary" id="endBtn" disabled>Encerrar</button>
+            <button class="secondary" id="testBtn">Testar câmera/microfone</button>
+          </div>
+          <div id="info" class="footer">Aguardando...</div>
+          <div id="chatContainer" class="chat hidden">
+            <div id="messages" class="chat-messages"></div>
+            <div class="chat-input">
+              <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
+              <button id="sendBtn" class="primary" disabled>Enviar</button>
+            </div>
+            <button id="backBtn" class="secondary" style="margin-top:8px;">Voltar</button>
+          </div>
+        </div>
+        <div id="videoContainer" class="videos">
+          <div class="video-box">
+            <video id="remoteVideo" playsinline autoplay></video>
+            <div class="muted-note">Remoto</div>
+          </div>
+          <div class="video-box">
+            <video id="localVideo" playsinline autoplay muted></video>
+            <div class="muted-note">Você (mudo)</div>
+          </div>
+        </div>
       </div>
     </div>
+  </section>
 
-    <div class="panel hero" style="margin-top:14px;">
-      <div>
-        <h1 style="margin:0 0 8px 0; font-size:28px;">Fale com um advogado agora</h1>
-        <p style="margin:0 0 14px 0; color: var(--muted);">
-          Atendimento por chamada de vídeo e áudio, diretamente no seu navegador.
-        </p>
-        <div class="actions">
-          <button class="primary" id="callBtn">Ligar agora</button>
-          <button class="secondary" id="endBtn" disabled>Encerrar</button>
-          <button class="secondary" id="testBtn">Testar câmera/microfone</button>
-        </div>
-        <div id="info" class="footer">Aguardando...</div>
-      </div>
-      <div class="videos">
-        <div class="video-box">
-          <video id="remoteVideo" playsinline autoplay></video>
-          <div class="muted-note">Remoto</div>
-        </div>
-        <div class="video-box">
-          <video id="localVideo" playsinline autoplay muted></video>
-          <div class="muted-note">Você (mudo)</div>
-        </div>
-      </div>
+  <section class="hero-section">
+    <div class="container">
+      <h1>Defendendo seus direitos com excelência</h1>
+      <p>Atendimento jurídico moderno, humano e eficiente.</p>
+      <button class="primary" onclick="document.getElementById('contato').scrollIntoView({behavior:'smooth'})">Fale agora</button>
     </div>
+  </section>
 
-    <div class="footer">
-      Conexão segura via WebRTC. Use Chrome/Edge/Firefox atualizados.
+  <section id="sobre" class="about-section">
+    <div class="container">
+      <h2>Sobre</h2>
+      <p>Atuamos com dedicação e transparência para garantir a melhor defesa dos seus interesses. Utilizamos tecnologia de ponta para agilizar seu atendimento.</p>
     </div>
-  </div>
+  </section>
+
+  <section id="areas" class="areas-section">
+    <div class="container">
+      <h2>Áreas de Atuação</h2>
+      <div class="areas-grid">
+        <div class="area-card">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0 0 12 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 0 1-2.031.352 5.988 5.988 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971Zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 0 1-2.031.352 5.989 5.989 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L5.25 4.971Z"/></svg>
+          <span>Direito Civil</span>
+        </div>
+        <div class="area-card">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0M12 12.75h.008v.008H12v-.008Z"/></svg>
+          <span>Direito Trabalhista</span>
+        </div>
+        <div class="area-card">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008Zm0 3h.008v.008h-.008v-.008Zm0 3h.008v.008h-.008v-.008Z"/></svg>
+          <span>Direito Empresarial</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="formulario" class="form-section">
+    <div class="container">
+      <h2>Envie uma mensagem</h2>
+      <form class="contact-form">
+        <input type="text" name="nome" placeholder="Seu nome" required />
+        <input type="email" name="email" placeholder="Seu e-mail" required />
+        <textarea name="mensagem" rows="5" placeholder="Sua mensagem" required></textarea>
+        <button type="submit" class="primary">Enviar</button>
+      </form>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div>© 2024 Escritório de Advocacia Online. Todos os direitos reservados.</div>
+      <div class="social-links">
+        <a href="#" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" width="20" height="20"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.22 8.5h4.56V24H.22V8.5zM8.98 8.5h4.37v2.11h.06c.61-1.15 2.11-2.37 4.33-2.37 4.63 0 5.48 3.05 5.48 7.02V24h-4.56v-7.37c0-1.76-.03-4.03-2.46-4.03-2.46 0-2.84 1.92-2.84 3.9V24H8.98V8.5z"/></svg></a>
+        <a href="#" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="20" height="20"><rect width="20" height="20" x="2" y="2" rx="5" ry="5" stroke-width="2"/><path stroke-width="2" d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><circle cx="17.5" cy="6.5" r="1.5" fill="currentColor"/></svg></a>
+        <a href="#" aria-label="Facebook"><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" width="20" height="20"><path d="M22.675 0h-21.35C.597 0 0 .597 0 1.326v21.348C0 23.403.597 24 1.326 24h11.495V14.708H9.692v-3.622h3.129V8.413c0-3.1 1.893-4.788 4.659-4.788 1.325 0 2.463.099 2.795.143v3.24l-1.918.001c-1.504 0-1.796.715-1.796 1.763v2.313h3.587l-.467 3.622h-3.12V24h6.116C23.403 24 24 23.403 24 22.674V1.326C24 .597 23.403 0 22.675 0z"/></svg></a>
+      </div>
+    </div>
+  </footer>
 
   <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="/client.js"></script>
+  <script src="/background.js"></script>
 </body>
 </html>

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -39,6 +39,14 @@
       </div>
       <div id="info" class="footer">Aguardando chamadas...</div>
     </div>
+    <div class="panel" style="margin-top:14px;" id="chatPanel">
+      <h3 style="margin-top:0;">Chat de Texto</h3>
+      <div id="messages" class="chat-messages"></div>
+      <div class="chat-input">
+        <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
+        <button id="sendBtn" class="primary" disabled>Enviar</button>
+      </div>
+    </div>
   </div>
 
   <div class="incoming" id="incoming">

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -8,6 +8,9 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const acceptBtn = document.getElementById('acceptBtn');
   const rejectBtn = document.getElementById('rejectBtn');
   const hangupBtn = document.getElementById('hangupBtn');
+  const messages = document.getElementById('messages');
+  const chatInput = document.getElementById('chatInput');
+  const sendBtn = document.getElementById('sendBtn');
 
   const socket = io();
   socket.emit('identify', { role: 'lawyer' });
@@ -15,12 +18,15 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   let pc = null; // RTCPeerConnection
   let localStream = null;
   let currentClientId = null;
+  let pendingMode = 'video';
+  let currentChatClientId = null;
 
   function setInfo(text) { info.textContent = text; }
 
   let pendingClientId = null;
-  socket.on('incoming-call', ({ clientId }) => {
+  socket.on('incoming-call', ({ clientId, mode }) => {
     pendingClientId = clientId;
+    pendingMode = mode || 'video';
     incoming.style.display = 'flex';
   });
 
@@ -37,7 +43,7 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     incoming.style.display = 'none';
     setInfo('Preparando mídia...');
     try {
-      const res = await getMediaWithFallback();
+      const res = await getMediaWithFallback(pendingMode);
       localStream = res.stream;
       localVideo.srcObject = localStream;
       pc = createPeerConnection(currentClientId);
@@ -56,6 +62,33 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   hangupBtn.addEventListener('click', () => {
     if (currentClientId) socket.emit('end-call', { targetId: currentClientId });
     endCall('Você encerrou a chamada.');
+  });
+
+  // Chat
+  function appendMessage(sender, text) {
+    const div = document.createElement('div');
+    div.textContent = `${sender}: ${text}`;
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  function sendChat() {
+    const msg = chatInput.value.trim();
+    if (!msg || !currentChatClientId) return;
+    appendMessage('Você', msg);
+    socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
+    chatInput.value = '';
+  }
+
+  sendBtn.addEventListener('click', sendChat);
+  chatInput.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); sendChat(); }
+  });
+
+  socket.on('chat-message', ({ from, message }) => {
+    currentChatClientId = from;
+    appendMessage('Cliente', message);
+    sendBtn.disabled = false;
   });
 
   socket.on('webrtc-offer', async ({ from, sdp }) => {

--- a/public/media.js
+++ b/public/media.js
@@ -1,5 +1,9 @@
 // Utilitários para capturar mídia com mensagens claras e fallbacks
-export async function getMediaWithFallback() {
+export async function getMediaWithFallback(mode = 'video') {
+  if (mode === 'audio') {
+    const s = await navigator.mediaDevices.getUserMedia({ video: false, audio: { echoCancellation: true, noiseSuppression: true } });
+    return { stream: s, note: 'Somente áudio ativo.' };
+  }
   const constraintsBoth = { video: { width: { ideal: 1280 }, height: { ideal: 720 } }, audio: { echoCancellation: true, noiseSuppression: true } };
   try {
     const s = await navigator.mediaDevices.getUserMedia(constraintsBoth);

--- a/public/style.css
+++ b/public/style.css
@@ -5,21 +5,58 @@
   --accent-2: #ef4444; /* red-500 */
   --text: #e5e7eb; /* gray-200 */
   --muted: #94a3b8; /* slate-400 */
+  --bg-x: 50%;
+  --bg-y: 50%;
 }
 
 * { box-sizing: border-box; }
 html, body { height: 100%; }
 body {
-  margin: 0;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  background: linear-gradient(120deg, #0f172a 0%, #0b1224 100%);
-  color: var(--text);
+    margin: 0;
+    font-family: 'Poppins', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+    background: linear-gradient(120deg, #0f172a 0%, #0b1224 100%);
+    color: var(--text);
+    line-height: 1.6;
+    position: relative;
+    z-index: 0;
+  }
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at var(--bg-x) var(--bg-y), rgba(34,197,94,0.15), transparent 60%);
+  pointer-events: none;
+  z-index: -1;
+  transition: background 0.15s;
 }
 
 .container {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 16px;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 16px;
+  }
+
+h1, h2, h3 {
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+h2 {
+  font-size: 32px;
+  margin-bottom: 24px;
+  text-align: center;
+  position: relative;
+}
+
+h2::after {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 999px;
+  margin: 8px auto 0;
 }
 
 .header {
@@ -36,6 +73,8 @@ body {
 }
 
 .badge {
+  display: inline-flex;
+  align-items: center;
   padding: 3px 10px;
   border-radius: 999px;
   font-size: 12px;
@@ -43,15 +82,30 @@ body {
   color: var(--muted);
 }
 
+.badge::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ef4444; /* red */
+  margin-right: 6px;
+}
+
 .badge.online {
   color: #052e16;
   background: #bbf7d0; /* green-200 */
 }
 
+.badge.online::before { background: #22c55e; }
+
 .badge.busy {
-  color: #450a0a;
-  background: #fecaca; /* red-200 */
+  color: #78350f;
+  background: #fef9c3; /* yellow-100 */
 }
+
+.badge.busy::before { background: #f59e0b; }
+
+.badge.offline::before { background: #ef4444; }
 
 .panel {
   background: rgba(17, 24, 39, 0.75);
@@ -59,6 +113,13 @@ body {
   border-radius: 14px;
   padding: 16px;
   backdrop-filter: blur(8px);
+}
+
+.contact-panel {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: center;
 }
 
 .hero {
@@ -75,25 +136,50 @@ body {
 }
 
 button.primary {
-  background: linear-gradient(90deg, #22c55e, #16a34a);
-  color: #052e16;
-  border: none;
+    background: linear-gradient(90deg, #22c55e, #16a34a);
+    color: #052e16;
+    border: none;
   border-radius: 10px;
   padding: 12px 16px;
   font-weight: 600;
-  cursor: pointer;
-}
+    cursor: pointer;
+    transition: filter 0.3s, transform 0.2s;
+  }
 
 button.secondary {
-  background: transparent;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  color: var(--text);
-  border-radius: 10px;
-  padding: 12px 16px;
-  cursor: pointer;
+    background: transparent;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 12px 16px;
+    cursor: pointer;
+    transition: color 0.3s, border-color 0.3s, transform 0.2s;
+  }
+
+button.primary:hover {
+  filter: brightness(1.1);
+  transform: translateY(-2px);
+}
+
+button.secondary:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  transform: translateY(-2px);
 }
 
 button.danger { background: #ef4444; color: white; }
+
+.hidden { display: none; }
+
+.mode-options {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+  font-size: 14px;
+}
+
+.mode-options label { display: flex; align-items: center; gap: 6px; cursor: pointer; }
 
 .videos {
   display: grid;
@@ -151,8 +237,175 @@ button.danger { background: #ef4444; color: white; }
   color: var(--muted);
 }
 
+.chat {
+  display: flex;
+  flex-direction: column;
+  margin-top: 16px;
+}
+
+.chat-messages {
+  flex: 1;
+  min-height: 160px;
+  max-height: 260px;
+  overflow-y: auto;
+  background: #0b1224;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 8px;
+  padding: 8px;
+  margin-bottom: 8px;
+}
+
+.chat-input {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-input input {
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #0b1224;
+  color: var(--text);
+}
+
+.chat-input button { flex-shrink: 0; }
+
 @media (max-width: 900px) {
   .hero { grid-template-columns: 1fr; }
   .videos { grid-template-columns: 1fr; }
+  .contact-panel { grid-template-columns: 1fr; }
 }
 
+body { scroll-behavior: smooth; }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  z-index: 50;
+}
+
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  margin-left: 16px;
+  transition: color 0.3s;
+  font-weight: 500;
+}
+
+.nav-links a:hover { color: var(--accent); }
+
+.hero-section {
+  text-align: center;
+  padding: 100px 16px;
+  background: linear-gradient(135deg, #0b1224 0%, #141e31 100%);
+  animation: fadeIn 1s ease forwards;
+}
+
+.hero-section h1 { font-size: 42px; margin-bottom: 16px; }
+.hero-section p { color: var(--muted); margin-bottom: 24px; }
+
+.about-section,
+.areas-section,
+.contact-section {
+  padding: 80px 16px;
+}
+
+.contact-section {
+  padding: 40px 16px;
+}
+
+.areas-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+  }
+
+.area-card {
+    flex: 1 1 200px;
+    background: rgba(17, 24, 39, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    border-radius: 12px;
+    padding: 24px 16px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    font-weight: 500;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    transition: transform 0.3s, box-shadow 0.3s;
+  }
+
+.area-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.3);
+}
+
+.area-card svg {
+  width: 40px;
+  height: 40px;
+  stroke: var(--accent);
+}
+
+.site-footer {
+  background: #0b1224;
+  padding: 32px 16px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.site-footer .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.site-footer .social-links {
+  display: flex;
+  gap: 16px;
+}
+
+.site-footer .social-links a {
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.3s;
+  display: inline-flex;
+}
+
+.site-footer .social-links a:hover { color: var(--accent); }
+
+.form-section {
+  padding: 60px 16px;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #0b1224;
+  color: var(--text);
+  font-family: inherit;
+}
+
+.contact-form textarea { resize: vertical; }
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ io.on('connection', (socket) => {
   });
 
   // Cliente pede para iniciar uma chamada
-  socket.on('request-call', () => {
+  socket.on('request-call', ({ mode }) => {
     if (!lawyerSocket) {
       socket.emit('call-unavailable', { reason: 'offline' });
       return;
@@ -74,7 +74,7 @@ io.on('connection', (socket) => {
     }
     busyWithClientId = socket.id;
     broadcastLawyerStatus();
-    lawyerSocket.emit('incoming-call', { clientId: socket.id });
+    lawyerSocket.emit('incoming-call', { clientId: socket.id, mode });
   });
 
   // Advogado aceita a chamada
@@ -112,6 +112,16 @@ io.on('connection', (socket) => {
   });
   socket.on('webrtc-ice-candidate', ({ targetId, candidate }) => {
     if (targetId && candidate) io.to(targetId).emit('webrtc-ice-candidate', { from: socket.id, candidate });
+  });
+
+  // Mensagens de chat de texto
+  socket.on('chat-message', ({ targetId, message }) => {
+    if (!message) return;
+    if (lawyerSocket && socket.id === lawyerSocket.id) {
+      if (targetId) io.to(targetId).emit('chat-message', { from: 'lawyer', message });
+    } else {
+      if (lawyerSocket) lawyerSocket.emit('chat-message', { from: socket.id, message });
+    }
   });
 
   socket.on('disconnect', () => {


### PR DESCRIPTION
## Summary
- Hide contact link and section unless the lawyer is online and show a green or red status dot in the header
- Let users switch to text chat which hides other call modes and differentiate audio calls by removing video boxes
- Refresh header and footer styling with an online office tagline and social media icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js` *(Servidor iniciado em http://localhost:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68a9087414b8832db0f9d7d9b90d46d4