### PR TITLE
feat: adiciona chat com IA e painel admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.19.2",
-        "socket.io": "^4.7.5"
+        "express-rate-limit": "^6.10.0",
+        "multer": "^1.4.5-lts.1",
+        "node-fetch": "^2.6.7",
+        "socket.io": "^4.7.5",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -49,6 +53,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -89,6 +99,23 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -127,6 +154,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -161,6 +203,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -385,6 +433,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
+      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -546,6 +606,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -615,11 +681,51 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -628,6 +734,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -676,6 +802,12 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -729,6 +861,27 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1007,6 +1160,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1015,6 +1191,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1028,6 +1210,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.10.0",
@@ -1043,6 +1231,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -1060,6 +1254,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/ws": {
@@ -1081,6 +1291,24 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.19.2",
-    "socket.io": "^4.7.5"
+    "express-rate-limit": "^6.10.0",
+    "multer": "^1.4.5-lts.1",
+    "node-fetch": "^2.6.7",
+    "socket.io": "^4.7.5",
+    "zod": "^3.22.4"
   }
 }
-

--- a/providers.js
+++ b/providers.js
@@ -1,0 +1,85 @@
+const fetch = require('node-fetch');
+
+async function openaiGenerate(apiKey, messages, params) {
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: params.model || 'gpt-4o-mini',
+      input: messages,
+      max_output_tokens: params.max_output_tokens,
+      temperature: params.temperature,
+      top_p: params.top_p,
+      stop: params.stop_sequences
+    })
+  });
+  const data = await res.json();
+  if (data.output && data.output.length) {
+    return data.output[0].content[0].text;
+  }
+  return data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content || '';
+}
+
+async function anthropicGenerate(apiKey, messages, params) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: params.model || 'claude-3-haiku-20240307',
+      max_tokens: params.max_output_tokens,
+      temperature: params.temperature,
+      top_p: params.top_p,
+      stop_sequences: params.stop_sequences,
+      messages
+    })
+  });
+  const data = await res.json();
+  if (data.content && data.content.length) {
+    return data.content[0].text;
+  }
+  return '';
+}
+
+async function groqGenerate(apiKey, messages, params) {
+  const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: params.model || 'mixtral-8x7b-32768',
+      messages,
+      max_tokens: params.max_output_tokens,
+      temperature: params.temperature,
+      top_p: params.top_p,
+      stop: params.stop_sequences
+    })
+  });
+  const data = await res.json();
+  if (data.choices && data.choices.length) {
+    return data.choices[0].message.content;
+  }
+  return '';
+}
+
+async function generate(provider, apiKey, messages, params) {
+  switch (provider) {
+    case 'anthropic':
+      return anthropicGenerate(apiKey, messages, params);
+    case 'groq':
+      return groqGenerate(apiKey, messages, params);
+    case 'openai':
+    default:
+      return openaiGenerate(apiKey, messages, params);
+  }
+}
+
+module.exports = { generate };

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="pt-br">
+<head>
+  <meta charset="utf-8" />
+  <title>Painel Admin</title>
+</head>
+<body>
+  <h1>Painel Administrativo</h1>
+  <form id="configForm">
+    <label>Provedor
+      <select name="provider">
+        <option value="openai">OpenAI</option>
+        <option value="anthropic">Anthropic</option>
+        <option value="groq">Groq</option>
+      </select>
+    </label>
+    <label>Max tokens <input type="number" name="max_output_tokens" /></label>
+    <label>Temperature <input type="number" step="0.1" name="temperature" /></label>
+    <label>Top P <input type="number" step="0.1" name="top_p" /></label>
+    <label>Prompt<br/><textarea name="prompt" rows="4" cols="40"></textarea></label>
+    <button type="submit">Salvar</button>
+  </form>
+  <form id="keyForm">
+    <h2>API Keys</h2>
+    <label>OpenAI <input type="password" name="openai" /></label>
+    <label>Anthropic <input type="password" name="anthropic" /></label>
+    <label>Groq <input type="password" name="groq" /></label>
+    <button type="submit">Salvar chaves</button>
+  </form>
+  <script src="/admin.js"></script>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,36 @@
+async function post(path, data) {
+  const key = prompt('Chave admin?');
+  await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+    body: JSON.stringify(data)
+  });
+}
+
+document.getElementById('configForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fd = new FormData(e.target);
+  const data = {
+    provider: fd.get('provider'),
+    parameters: {
+      max_output_tokens: Number(fd.get('max_output_tokens')),
+      temperature: Number(fd.get('temperature')),
+      top_p: Number(fd.get('top_p'))
+    },
+    prompt: fd.get('prompt')
+  };
+  await post('/admin/config', data);
+  alert('Configuração salva');
+});
+
+document.getElementById('keyForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fd = new FormData(e.target);
+  const data = {
+    openai: fd.get('openai'),
+    anthropic: fd.get('anthropic'),
+    groq: fd.get('groq')
+  };
+  await post('/admin/keys', data);
+  alert('Chaves salvas');
+});

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,19 @@
       </nav>
     </div>
   </header>
+  <section id="secretaria" class="secretary-section">
+    <div class="container">
+      <h2>Secretária Virtual</h2>
+      <div id="aiChat" class="chat">
+        <div id="aiMessages" class="chat-messages"></div>
+        <div id="quickReplies" class="quick-replies"></div>
+        <div class="chat-input">
+          <input id="aiInput" type="text" placeholder="Digite sua mensagem" />
+          <button id="aiSend" class="primary">Enviar</button>
+        </div>
+      </div>
+    </div>
+  </section>
   <section id="contato" class="contact-section hidden">
     <div class="container">
       <h2>Contato</h2>
@@ -132,5 +145,6 @@
   <script type="module" src="/client.js"></script>
   <script src="/background.js"></script>
   <script src="/main.js"></script>
+  <script src="/secretary.js"></script>
 </body>
 </html>

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -47,6 +47,32 @@
         <button id="sendBtn" class="primary" disabled>Enviar</button>
       </div>
     </div>
+    <div class="panel" style="margin-top:14px;" id="aiConfigPanel">
+      <h3 style="margin-top:0;">Configuração da IA</h3>
+      <form id="aiConfigForm">
+        <label>Chave Admin
+          <input type="password" id="adminKey" required />
+        </label>
+        <label>Provedor
+          <select name="provider">
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="groq">Groq</option>
+          </select>
+        </label>
+        <label>Modelo<input type="text" name="model" /></label>
+        <label>Max tokens<input type="number" name="max_output_tokens" /></label>
+        <label>Temperatura<input type="number" step="0.1" name="temperature" /></label>
+        <label>Prompt<textarea name="prompt" rows="3"></textarea></label>
+        <button type="submit" class="primary">Salvar Configuração</button>
+      </form>
+      <form id="aiKeyForm" style="margin-top:12px;">
+        <label>OpenAI<input type="password" name="openai" /></label>
+        <label>Anthropic<input type="password" name="anthropic" /></label>
+        <label>Groq<input type="password" name="groq" /></label>
+        <button type="submit" class="secondary">Salvar Chaves</button>
+      </form>
+    </div>
   </div>
 
   <div class="incoming" id="incoming">

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -173,4 +173,49 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
   }
+
+  // Configuração da IA
+  const aiConfigForm = document.getElementById('aiConfigForm');
+  const aiKeyForm = document.getElementById('aiKeyForm');
+  const adminKeyInput = document.getElementById('adminKey');
+
+  async function adminPost(path, data) {
+    const key = adminKeyInput.value.trim();
+    if (!key) { alert('Informe a chave admin'); return; }
+    await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+      body: JSON.stringify(data)
+    });
+  }
+
+  if (aiConfigForm) {
+    aiConfigForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const fd = new FormData(aiConfigForm);
+      const data = {
+        provider: fd.get('provider'),
+        parameters: {
+          model: fd.get('model') || undefined,
+          max_output_tokens: Number(fd.get('max_output_tokens')) || undefined,
+          temperature: Number(fd.get('temperature')) || undefined
+        },
+        prompt: fd.get('prompt')
+      };
+      adminPost('/admin/config', data).then(() => alert('Configuração salva'));
+    });
+  }
+
+  if (aiKeyForm) {
+    aiKeyForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const fd = new FormData(aiKeyForm);
+      const data = {
+        openai: fd.get('openai'),
+        anthropic: fd.get('anthropic'),
+        groq: fd.get('groq')
+      };
+      adminPost('/admin/keys', data).then(() => alert('Chaves salvas'));
+    });
+  }
 })();

--- a/public/secretary.js
+++ b/public/secretary.js
@@ -1,0 +1,240 @@
+const messagesEl = document.getElementById('aiMessages');
+const quickRepliesEl = document.getElementById('quickReplies');
+const chatInputContainer = document.querySelector('#aiChat .chat-input');
+const aiInput = document.getElementById('aiInput');
+const aiSend = document.getElementById('aiSend');
+if (chatInputContainer) chatInputContainer.style.display = 'none';
+const sessionId = crypto.randomUUID();
+
+function append(role, content) {
+  const div = document.createElement('div');
+  div.className = 'msg ' + role;
+  if (typeof content === 'string') div.textContent = content;
+  else div.appendChild(content);
+  messagesEl.appendChild(div);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+const triageData = { documentos: [] };
+let step = 0;
+
+const steps = [
+  {
+    question: 'Vamos começar com seus dados.',
+    fields: [
+      { name: 'nome', label: 'Nome', type: 'text', required: true },
+      { name: 'contato', label: 'Contato (email ou telefone)', type: 'text', required: true }
+    ]
+  },
+  {
+    question: 'Sobre o caso.',
+    fields: [
+      { name: 'tipo', label: 'Tipo do caso', type: 'select', options: ['Cível','Trabalhista','Empresarial'], required: true },
+      { name: 'descricao', label: 'Descreva brevemente', type: 'textarea', required: true }
+    ]
+  },
+  {
+    question: 'Prazos e risco.',
+    fields: [
+      { name: 'prazo', label: 'Existe algum prazo?', type: 'date', required: false },
+      { name: 'risco', label: 'Nível de risco', type: 'radio', options: ['Baixo','Médio','Alto'], required: true }
+    ]
+  },
+  {
+    question: 'Envie documentos (opcional).',
+    fields: [
+      { name: 'documento', label: 'Documento', type: 'file', required: false }
+    ]
+  },
+  {
+    question: 'Posso encerrar o atendimento?',
+    fields: [
+      { name: 'encerrar', type: 'radio', options: ['Sim','Não'], required: true }
+    ]
+  }
+];
+
+function renderQuickReplies() {
+  if (!quickRepliesEl) return;
+  quickRepliesEl.innerHTML = '';
+  ['Sim', 'Não', 'Obrigado'].forEach(text => {
+    const btn = document.createElement('button');
+    btn.textContent = text;
+    btn.addEventListener('click', () => sendChat(text));
+    quickRepliesEl.appendChild(btn);
+  });
+}
+
+async function sendChat(message) {
+  append('user', message);
+  try {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, message })
+    });
+    const data = await res.json();
+    if (data.reply) append('assistant', data.reply);
+  } catch (e) {
+    append('assistant', '[erro]');
+  }
+  renderQuickReplies();
+}
+
+aiSend.addEventListener('click', () => {
+  const msg = aiInput.value.trim();
+  if (!msg) return;
+  aiInput.value = '';
+  sendChat(msg);
+});
+
+aiInput.addEventListener('keypress', e => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    aiSend.click();
+  }
+});
+
+function renderStep() {
+  if (step >= steps.length) {
+    finalize();
+    return;
+  }
+  const s = steps[step];
+  append('assistant', s.question);
+  const form = document.createElement('form');
+  form.className = 'triage-form';
+  s.fields.forEach(f => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'field';
+    const label = document.createElement('label');
+    label.textContent = f.label;
+    wrapper.appendChild(label);
+    let input;
+    if (f.type === 'select') {
+      input = document.createElement('select');
+      f.options.forEach(o => {
+        const op = document.createElement('option');
+        op.value = o;
+        op.textContent = o;
+        input.appendChild(op);
+      });
+    } else if (f.type === 'textarea') {
+      input = document.createElement('textarea');
+    } else if (f.type === 'radio') {
+      input = document.createElement('div');
+      f.options.forEach(o => {
+        const lbl = document.createElement('label');
+        const rb = document.createElement('input');
+        rb.type = 'radio';
+        rb.name = f.name;
+        rb.value = o;
+        lbl.appendChild(rb);
+        lbl.appendChild(document.createTextNode(o));
+        input.appendChild(lbl);
+      });
+    } else {
+      input = document.createElement('input');
+      input.type = f.type;
+      if (f.type === 'file') input.accept = '.pdf,.png,.jpg,.jpeg';
+    }
+    input.name = f.name;
+    wrapper.appendChild(input);
+    form.appendChild(wrapper);
+  });
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.textContent = 'Enviar';
+  form.appendChild(submit);
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    handleStep(form, s);
+  });
+  append('assistant', form);
+}
+
+async function handleStep(form, s) {
+  const data = new FormData(form);
+  for (const f of s.fields) {
+    if (f.type === 'radio') {
+      const val = data.get(f.name);
+      if (f.required && !val) return alert('Preencha todos os campos obrigatórios.');
+      if (val) triageData[f.name] = val;
+    } else if (f.type === 'file') {
+      const file = data.get(f.name);
+      if (file && file.size) {
+        try {
+          const uploaded = await uploadFile(file);
+          triageData.documentos.push(uploaded);
+        } catch (e) {
+          alert('Falha no upload');
+          return;
+        }
+      } else if (f.required) return alert('Arquivo obrigatório');
+    } else {
+      const val = data.get(f.name);
+      if (f.required && !val) return alert('Preencha todos os campos obrigatórios.');
+      if (val) triageData[f.name] = val;
+    }
+  }
+  if (s.fields.length) {
+    const summary = s.fields.map(f => `${f.label}: ${triageData[f.name] || ''}`).join(' | ');
+    append('user', summary);
+  }
+  if (s.fields.some(f => f.name === 'encerrar')) {
+    if (triageData.encerrar === 'Não') {
+      append('assistant', 'Tudo bem, continuaremos quando estiver pronto.');
+      return;
+    }
+  }
+  step++;
+  renderStep();
+}
+
+async function uploadFile(file) {
+  const fd = new FormData();
+  fd.append('file', file);
+  const res = await fetch('/api/upload', { method: 'POST', body: fd });
+  const js = await res.json();
+  if (js.error) throw new Error(js.error);
+  return js.file;
+}
+
+async function finalize() {
+  try {
+    const res = await fetch('/api/triage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(triageData)
+    });
+    const data = await res.json();
+    append('assistant', 'Resumo factual:');
+    const ul1 = document.createElement('ul');
+    (data.summary || []).forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      ul1.appendChild(li);
+    });
+    append('assistant', ul1);
+    append('assistant', 'Checklist de pendências:');
+    const ul2 = document.createElement('ul');
+    (data.checklist || []).forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      ul2.appendChild(li);
+    });
+    append('assistant', ul2);
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(data.data, null, 2);
+    append('assistant', pre);
+  } catch (e) {
+    append('assistant', '[erro ao gerar resumo]');
+  }
+  append('assistant', 'Posso ajudar com mais algo?');
+  if (chatInputContainer) {
+    chatInputContainer.style.display = 'flex';
+    renderQuickReplies();
+  }
+}
+
+renderStep();

--- a/public/style.css
+++ b/public/style.css
@@ -255,6 +255,39 @@ button.danger { background: #ef4444; color: white; }
   margin-bottom: 8px;
 }
 
+.chat-messages .msg {
+  margin-bottom: 4px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  white-space: pre-wrap;
+}
+
+.chat-messages .msg.user {
+  background: #1e293b;
+  text-align: right;
+}
+
+.chat-messages .msg.assistant {
+  background: #334155;
+}
+
+.quick-replies {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.quick-replies button {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
 .chat-input {
   display: flex;
   gap: 8px;
@@ -428,4 +461,21 @@ body { scroll-behavior: smooth; }
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(20px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+.triage-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.triage-form .field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.triage-form button {
+  align-self: flex-end;
 }

--- a/server.js
+++ b/server.js
@@ -4,6 +4,10 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const { Server } = require('socket.io');
+const rateLimit = require('express-rate-limit');
+const { z } = require('zod');
+const { generate } = require('./providers');
+const multer = require('multer');
 
 const app = express();
 
@@ -35,12 +39,187 @@ const io = new Server(server, {
 // Middleware
 app.use(express.static('public'));
 app.use(express.json());
+const chatLimiter = rateLimit({ windowMs: 60 * 1000, max: 20 });
+
+// Configuração de upload de arquivos
+fs.mkdirSync(path.join(__dirname, 'uploads'), { recursive: true });
+const upload = multer({
+  dest: path.join(__dirname, 'uploads'),
+  limits: { fileSize: 2 * 1024 * 1024 }, // 2MB
+  fileFilter: (req, file, cb) => {
+    const allowed = ['application/pdf', 'image/png', 'image/jpeg'];
+    if (allowed.includes(file.mimetype)) cb(null, true);
+    else cb(new Error('invalid_file_type'));
+  }
+});
+
+const adminConfig = {
+  provider: 'openai',
+  parameters: {
+    model: 'gpt-4o-mini',
+    max_output_tokens: 500,
+    temperature: 0.7,
+    top_p: 1,
+    stop_sequences: []
+  },
+  prompt: 'Você é um advogado especialista. Responda em português com frases curtas e objetivas.',
+  limits: { maxMessages: 20, maxChars: 1000 },
+  features: { upload: false, ocr: false },
+  apiKeys: {
+    openai: process.env.OPENAI_API_KEY || '',
+    anthropic: process.env.ANTHROPIC_API_KEY || '',
+    groq: process.env.GROQ_API_KEY || ''
+  }
+};
+
+const sessions = {};
 
 // Endpoint simples para formulário de contato
 app.post('/contact', (req, res) => {
   const { nome, email, mensagem } = req.body || {};
   console.log('Contato recebido:', nome, email, mensagem);
   res.sendStatus(200);
+});
+
+const messageSchema = z.object({
+  sessionId: z.string(),
+  message: z.string().min(1)
+});
+
+const triageSchema = z.object({
+  nome: z.string().min(1),
+  contato: z.string().min(1),
+  tipo: z.string().min(1),
+  descricao: z.string().min(1),
+  prazo: z.string().optional(),
+  risco: z.enum(['Baixo', 'Médio', 'Alto']),
+  documentos: z.array(z.string()).optional()
+});
+
+app.post('/api/chat', chatLimiter, async (req, res) => {
+  const parsed = messageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'invalid_request' });
+  }
+  const { sessionId, message } = parsed.data;
+  if (message.length > adminConfig.limits.maxChars) {
+    return res.status(400).json({ error: 'msg_too_long' });
+  }
+  const session = sessions[sessionId] || { count: 0, messages: [] };
+  if (session.count >= adminConfig.limits.maxMessages) {
+    return res.status(400).json({ error: 'limit_reached' });
+  }
+  session.count++;
+  session.messages.push({ role: 'user', content: message });
+  sessions[sessionId] = session;
+  try {
+    const aiMessages = [{ role: 'system', content: adminConfig.prompt }, ...session.messages];
+    const reply = await generate(adminConfig.provider, adminConfig.apiKeys[adminConfig.provider], aiMessages, adminConfig.parameters);
+    session.messages.push({ role: 'assistant', content: reply });
+    res.json({ reply });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'provider_error' });
+  }
+});
+
+app.post('/api/upload', (req, res) => {
+  upload.single('file')(req, res, (err) => {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ file: req.file.filename });
+  });
+});
+
+app.post('/api/triage', async (req, res) => {
+  const parsed = triageSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'invalid_data' });
+  const data = parsed.data;
+  let summary = [];
+  let checklist = [];
+  try {
+    const aiMessages = [
+      {
+        role: 'system',
+        content: 'Gere um resumo factual em bullet points e um checklist de pendências. Responda em JSON com campos resumo e pendencias.'
+      },
+      { role: 'user', content: JSON.stringify(data) }
+    ];
+    const reply = await generate(
+      adminConfig.provider,
+      adminConfig.apiKeys[adminConfig.provider],
+      aiMessages,
+      adminConfig.parameters
+    );
+    const parsedReply = JSON.parse(reply);
+    summary = parsedReply.resumo || parsedReply.summary || [];
+    checklist = parsedReply.pendencias || parsedReply.checklist || [];
+    if (!Array.isArray(summary)) summary = [String(summary)];
+    if (!Array.isArray(checklist)) checklist = [String(checklist)];
+  } catch (e) {
+    summary = [
+      `Nome: ${data.nome}`,
+      `Contato: ${data.contato}`,
+      `Tipo de caso: ${data.tipo}`,
+      `Descrição: ${data.descricao}`,
+      data.prazo ? `Prazo: ${data.prazo}` : undefined,
+      `Risco: ${data.risco}`
+    ].filter(Boolean);
+    checklist = [];
+    if (!data.documentos || data.documentos.length === 0) {
+      checklist.push('Anexar documentos relevantes');
+    } else {
+      checklist.push('Revisar documentos enviados');
+    }
+    checklist.push('Advogado retornará contato');
+  }
+  res.json({ summary, checklist, data });
+});
+
+const adminKey = process.env.ADMIN_KEY || 'secret';
+
+const configSchema = z.object({
+  provider: z.enum(['openai', 'anthropic', 'groq']).optional(),
+  parameters: z.object({
+    model: z.string().optional(),
+    max_output_tokens: z.number().optional(),
+    temperature: z.number().optional(),
+    top_p: z.number().optional(),
+    stop_sequences: z.array(z.string()).optional()
+  }).partial().optional(),
+  prompt: z.string().optional(),
+  features: z.object({ upload: z.boolean().optional(), ocr: z.boolean().optional() }).partial().optional(),
+  limits: z.object({ maxMessages: z.number().optional(), maxChars: z.number().optional() }).partial().optional()
+});
+
+const keySchema = z.object({
+  openai: z.string().optional(),
+  anthropic: z.string().optional(),
+  groq: z.string().optional()
+});
+
+app.use('/admin', (req, res, next) => {
+  if (req.headers['x-admin-key'] !== adminKey) return res.sendStatus(401);
+  next();
+});
+
+app.get('/admin/config', (req, res) => {
+  const safe = { ...adminConfig };
+  delete safe.apiKeys;
+  res.json(safe);
+});
+
+app.post('/admin/config', (req, res) => {
+  const parsed = configSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'invalid_config' });
+  Object.assign(adminConfig, parsed.data);
+  res.json({ ok: true });
+});
+
+app.post('/admin/keys', (req, res) => {
+  const parsed = keySchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'invalid_keys' });
+  adminConfig.apiKeys = { ...adminConfig.apiKeys, ...parsed.data };
+  res.json({ ok: true });
 });
 
 let lawyerSocket = null; // socket do advogado


### PR DESCRIPTION
## Summary
- implementa adaptadores para OpenAI, Anthropic e Groq
- adiciona rota de chat com limitação e configuração dinâmica
- cria painel administrativo para escolher provedor e parâmetros
- adiciona triagem interativa com upload de arquivos e geração de resumo
- adiciona painel de configuração de IA para o advogado e respostas rápidas no chat

## Testing
- `npm test` (erro esperado: Missing script "test")
- `npm run build` (erro esperado: Missing script "build")
- `node -e "require('./server')"`


------
https://chatgpt.com/codex/tasks/task_e_68a9b0dc70e8832d83b152b66be14985