### PR TITLE
feat: add AI config and quick replies for lawyer chat

### DIFF
--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -42,10 +42,42 @@
     <div class="panel" style="margin-top:14px;" id="chatPanel">
       <h3 style="margin-top:0;">Chat de Texto</h3>
       <div id="messages" class="chat-messages"></div>
+      <div id="quickReplies" class="actions quick-replies">
+        <button class="secondary quick-reply" data-msg="Olá, como posso ajudar?">Saudação</button>
+        <button class="secondary quick-reply" data-msg="Poderia fornecer mais detalhes?">Mais detalhes</button>
+        <button class="secondary quick-reply" data-msg="Vamos agendar uma reunião para discutir melhor?">Agendar reunião</button>
+        <button class="secondary quick-reply" data-msg="Estou analisando seu caso e retornarei em breve.">Analisar</button>
+      </div>
       <div class="chat-input">
         <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
         <button id="sendBtn" class="primary" disabled>Enviar</button>
       </div>
+    </div>
+    <div class="panel" style="margin-top:14px;">
+      <h3 style="margin-top:0;">Configurações de IA</h3>
+      <form id="configForm" style="display:flex; flex-direction:column; gap:8px;">
+        <label>Provedor
+          <select name="provider">
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="groq">Groq</option>
+          </select>
+        </label>
+        <label>Max tokens <input type="number" name="max_output_tokens" value="200" /></label>
+        <label>Temperature <input type="number" step="0.1" name="temperature" value="0.7" /></label>
+        <label>Top P <input type="number" step="0.1" name="top_p" value="1" /></label>
+        <label>Prompt<br/>
+          <textarea name="prompt" rows="3">Você é um advogado profissional. Responda de forma curta, clara e educada em português.</textarea>
+        </label>
+        <button type="submit" class="primary">Salvar Config</button>
+      </form>
+      <form id="keyForm" style="display:flex; flex-direction:column; gap:8px; margin-top:12px;">
+        <h4 style="margin:0;">API Keys</h4>
+        <label>OpenAI <input type="password" name="openai" /></label>
+        <label>Anthropic <input type="password" name="anthropic" /></label>
+        <label>Groq <input type="password" name="groq" /></label>
+        <button type="submit" class="secondary">Salvar Chaves</button>
+      </form>
     </div>
   </div>
 

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -21,6 +21,50 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   let pendingMode = 'video';
   let currentChatClientId = null;
 
+  const configForm = document.getElementById('configForm');
+  const keyForm = document.getElementById('keyForm');
+
+  async function postAdmin(path, data) {
+    const key = prompt('Chave admin?');
+    await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+      body: JSON.stringify(data)
+    });
+  }
+
+  if (configForm) {
+    configForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(configForm);
+      const data = {
+        provider: fd.get('provider'),
+        parameters: {
+          max_output_tokens: Number(fd.get('max_output_tokens')),
+          temperature: Number(fd.get('temperature')),
+          top_p: Number(fd.get('top_p'))
+        },
+        prompt: fd.get('prompt')
+      };
+      await postAdmin('/admin/config', data);
+      alert('Configuração salva');
+    });
+  }
+
+  if (keyForm) {
+    keyForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(keyForm);
+      const data = {
+        openai: fd.get('openai'),
+        anthropic: fd.get('anthropic'),
+        groq: fd.get('groq')
+      };
+      await postAdmin('/admin/keys', data);
+      alert('Chaves salvas');
+    });
+  }
+
   function setInfo(text) { info.textContent = text; }
 
   let pendingClientId = null;
@@ -85,10 +129,28 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     if (e.key === 'Enter') { e.preventDefault(); sendChat(); }
   });
 
+  async function handleAiReply(clientId, msg) {
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: clientId, message: msg })
+      });
+      const data = await res.json();
+      if (data.reply) {
+        appendMessage('IA', data.reply);
+        socket.emit('chat-message', { targetId: clientId, message: data.reply });
+      }
+    } catch (e) {
+      console.error('AI error', e);
+    }
+  }
+
   socket.on('chat-message', ({ from, message }) => {
     currentChatClientId = from;
     appendMessage('Cliente', message);
     sendBtn.disabled = false;
+    handleAiReply(from, message);
   });
 
   socket.on('webrtc-offer', async ({ from, sdp }) => {
@@ -173,4 +235,13 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
   }
+
+  document.querySelectorAll('.quick-reply').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const msg = btn.dataset.msg;
+      if (!msg || !currentChatClientId) return;
+      appendMessage('Você', msg);
+      socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
+    });
+  });
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -135,6 +135,14 @@ h2::after {
   flex-wrap: wrap;
 }
 
+.quick-replies {
+  margin-bottom: 8px;
+}
+.quick-replies button {
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
 button.primary {
     background: linear-gradient(90deg, #22c55e, #16a34a);
     color: #052e16;

--- a/server.js
+++ b/server.js
@@ -44,12 +44,12 @@ const adminConfig = {
   provider: 'openai',
   parameters: {
     model: 'gpt-4o-mini',
-    max_output_tokens: 500,
+    max_output_tokens: 200,
     temperature: 0.7,
     top_p: 1,
     stop_sequences: []
   },
-  prompt: 'Você é uma secretária jurídica especialista. Conduza a triagem em blocos e responda em português.',
+  prompt: 'Você é um advogado profissional. Responda de forma curta, clara e educada em português.',
   limits: { maxMessages: 20, maxChars: 1000 },
   features: { upload: false, ocr: false },
   apiKeys: {


### PR DESCRIPTION
## Summary
- add quick reply buttons and AI config panel to lawyer dashboard
- allow saving API keys for OpenAI, Anthropic and Groq from lawyer UI
- auto-reply to clients using configurable AI prompt

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9b82352ec832dacbe4e4b589bd3ae