### PR TITLE
feat: add AI controls to lawyer panel

### DIFF
--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -42,10 +42,36 @@
     <div class="panel" style="margin-top:14px;" id="chatPanel">
       <h3 style="margin-top:0;">Chat de Texto</h3>
       <div id="messages" class="chat-messages"></div>
+      <div id="quickReplies" class="quick-replies">
+        <button class="quick" data-text="Olá, como posso ajudar?">Saudação</button>
+        <button class="quick" data-text="Preciso de mais detalhes do caso.">Pedir detalhes</button>
+        <button class="quick" data-text="Podemos agendar uma reunião.">Agendar reunião</button>
+      </div>
       <div class="chat-input">
         <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
         <button id="sendBtn" class="primary" disabled>Enviar</button>
       </div>
+    </div>
+
+    <div class="panel" style="margin-top:14px;" id="aiPanel">
+      <h3 style="margin-top:0;">Configuração de IA</h3>
+      <form id="aiConfigForm">
+        <label>Provedor
+          <select name="provider">
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="groq">Groq</option>
+          </select>
+        </label>
+        <label>Prompt<br/><textarea name="prompt" rows="3" cols="40"></textarea></label>
+        <button type="submit" class="primary">Salvar Config</button>
+      </form>
+      <form id="aiKeyForm" style="margin-top:10px;">
+        <label>OpenAI Key <input type="password" name="openai" /></label>
+        <label>Anthropic Key <input type="password" name="anthropic" /></label>
+        <label>Groq Key <input type="password" name="groq" /></label>
+        <button type="submit" class="primary">Salvar Chaves</button>
+      </form>
     </div>
   </div>
 

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -11,6 +11,9 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const messages = document.getElementById('messages');
   const chatInput = document.getElementById('chatInput');
   const sendBtn = document.getElementById('sendBtn');
+  const quickReplies = document.getElementById('quickReplies');
+  const aiConfigForm = document.getElementById('aiConfigForm');
+  const aiKeyForm = document.getElementById('aiKeyForm');
 
   const socket = io();
   socket.emit('identify', { role: 'lawyer' });
@@ -72,12 +75,63 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     messages.scrollTop = messages.scrollHeight;
   }
 
+  function emitChat(text) {
+    if (!text || !currentChatClientId) return;
+    appendMessage('Você', text);
+    socket.emit('chat-message', { targetId: currentChatClientId, message: text });
+  }
+
   function sendChat() {
     const msg = chatInput.value.trim();
-    if (!msg || !currentChatClientId) return;
-    appendMessage('Você', msg);
-    socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
+    emitChat(msg);
     chatInput.value = '';
+  }
+
+  // Respostas pré-fabricadas
+  if (quickReplies) {
+    quickReplies.querySelectorAll('button').forEach(btn => {
+      btn.disabled = true;
+      btn.addEventListener('click', () => {
+        const text = btn.dataset.text;
+        emitChat(text);
+      });
+    });
+  }
+
+  async function post(path, data) {
+    const key = prompt('Chave admin?');
+    await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+      body: JSON.stringify(data)
+    });
+  }
+
+  if (aiConfigForm) {
+    aiConfigForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(aiConfigForm);
+      const data = {
+        provider: fd.get('provider'),
+        prompt: fd.get('prompt')
+      };
+      await post('/admin/config', data);
+      alert('Configuração de IA salva');
+    });
+  }
+
+  if (aiKeyForm) {
+    aiKeyForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(aiKeyForm);
+      const data = {
+        openai: fd.get('openai'),
+        anthropic: fd.get('anthropic'),
+        groq: fd.get('groq')
+      };
+      await post('/admin/keys', data);
+      alert('Chaves salvas');
+    });
   }
 
   sendBtn.addEventListener('click', sendChat);
@@ -89,6 +143,9 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     currentChatClientId = from;
     appendMessage('Cliente', message);
     sendBtn.disabled = false;
+    if (quickReplies) {
+      quickReplies.querySelectorAll('button').forEach(b => (b.disabled = false));
+    }
   });
 
   socket.on('webrtc-offer', async ({ from, sdp }) => {
@@ -146,6 +203,11 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     remoteVideo.srcObject = null;
     hangupBtn.disabled = true;
     currentClientId = null;
+    currentChatClientId = null;
+    sendBtn.disabled = true;
+    if (quickReplies) {
+      quickReplies.querySelectorAll('button').forEach(b => (b.disabled = true));
+    }
     setInfo(message || 'Aguardando chamadas...');
   }
 

--- a/public/style.css
+++ b/public/style.css
@@ -445,3 +445,7 @@ body { scroll-behavior: smooth; }
   from { opacity: 0; transform: translateY(20px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+/* Respostas rápidas no chat do advogado */
+.quick-replies { margin: 8px 0; }
+.quick-replies button { margin-right: 6px; margin-bottom: 6px; }

--- a/server.js
+++ b/server.js
@@ -44,12 +44,14 @@ const adminConfig = {
   provider: 'openai',
   parameters: {
     model: 'gpt-4o-mini',
-    max_output_tokens: 500,
+    // Respostas mais curtas para o chat do advogado
+    max_output_tokens: 150,
     temperature: 0.7,
     top_p: 1,
     stop_sequences: []
   },
-  prompt: 'Você é uma secretária jurídica especialista. Conduza a triagem em blocos e responda em português.',
+  // Prompt ajustado para atuar como advogado
+  prompt: 'Você é um advogado atendendo um cliente via chat. Responda como advogado com frases curtas e claras em português.',
   limits: { maxMessages: 20, maxChars: 1000 },
   features: { upload: false, ocr: false },
   apiKeys: {


### PR DESCRIPTION
## Summary
- allow configuring provider and API keys directly from lawyer dashboard
- add quick reply buttons for faster chat responses
- tweak default AI prompt and token limit for shorter lawyer-style answers

## Testing
- `node --check server.js`
- `node --check public/lawyer.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9b82352ec832dacbe4e4b589bd3ae