### PR TITLE
feat: add Gemini provider and error feedback to lawyer chat

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -17,6 +17,9 @@ async function openaiGenerate(apiKey, messages, params) {
     })
   });
   const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error && data.error.message || JSON.stringify(data));
+  }
   if (data.output && data.output.length) {
     return data.output[0].content[0].text;
   }
@@ -41,6 +44,9 @@ async function anthropicGenerate(apiKey, messages, params) {
     })
   });
   const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error && data.error.message || JSON.stringify(data));
+  }
   if (data.content && data.content.length) {
     return data.content[0].text;
   }
@@ -64,8 +70,40 @@ async function groqGenerate(apiKey, messages, params) {
     })
   });
   const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error && data.error.message || JSON.stringify(data));
+  }
   if (data.choices && data.choices.length) {
     return data.choices[0].message.content;
+  }
+  return '';
+}
+
+async function geminiGenerate(apiKey, messages, params) {
+  const url = `https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent?key=${apiKey}`;
+  const contents = messages.map(m => ({
+    role: m.role === 'assistant' ? 'model' : 'user',
+    parts: [{ text: m.content }]
+  }));
+  const body = { contents };
+  const generationConfig = {};
+  if (params.max_output_tokens !== undefined) generationConfig.maxOutputTokens = params.max_output_tokens;
+  if (params.temperature !== undefined) generationConfig.temperature = params.temperature;
+  if (params.top_p !== undefined) generationConfig.topP = params.top_p;
+  if (params.stop_sequences) generationConfig.stopSequences = params.stop_sequences;
+  if (Object.keys(generationConfig).length) body.generationConfig = generationConfig;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error && data.error.message || JSON.stringify(data));
+  }
+  if (data.candidates && data.candidates.length) {
+    const parts = data.candidates[0].content && data.candidates[0].content.parts;
+    if (parts && parts.length) return parts[0].text || '';
   }
   return '';
 }
@@ -76,6 +114,8 @@ async function generate(provider, apiKey, messages, params) {
       return anthropicGenerate(apiKey, messages, params);
     case 'groq':
       return groqGenerate(apiKey, messages, params);
+    case 'gemini':
+      return geminiGenerate(apiKey, messages, params);
     case 'openai':
     default:
       return openaiGenerate(apiKey, messages, params);

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -42,10 +42,44 @@
     <div class="panel" style="margin-top:14px;" id="chatPanel">
       <h3 style="margin-top:0;">Chat de Texto</h3>
       <div id="messages" class="chat-messages"></div>
+      <div id="quickReplies" class="actions quick-replies">
+        <button class="secondary quick-reply" data-msg="Olá, como posso ajudar?">Saudação</button>
+        <button class="secondary quick-reply" data-msg="Poderia fornecer mais detalhes?">Mais detalhes</button>
+        <button class="secondary quick-reply" data-msg="Vamos agendar uma reunião para discutir melhor?">Agendar reunião</button>
+        <button class="secondary quick-reply" data-msg="Estou analisando seu caso e retornarei em breve.">Analisar</button>
+      </div>
       <div class="chat-input">
         <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
         <button id="sendBtn" class="primary" disabled>Enviar</button>
       </div>
+    </div>
+    <div class="panel" style="margin-top:14px;">
+      <h3 style="margin-top:0;">Configurações de IA</h3>
+      <form id="configForm" style="display:flex; flex-direction:column; gap:8px;">
+        <label>Provedor
+          <select name="provider">
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="groq">Groq</option>
+            <option value="gemini">Gemini</option>
+          </select>
+        </label>
+        <label>Max tokens <input type="number" name="max_output_tokens" value="200" /></label>
+        <label>Temperature <input type="number" step="0.1" name="temperature" value="0.7" /></label>
+        <label>Top P <input type="number" step="0.1" name="top_p" value="1" /></label>
+        <label>Prompt<br/>
+          <textarea name="prompt" rows="3">Você é um advogado profissional. Responda de forma curta, clara e educada em português.</textarea>
+        </label>
+        <button type="submit" class="primary">Salvar Config</button>
+      </form>
+      <form id="keyForm" style="display:flex; flex-direction:column; gap:8px; margin-top:12px;">
+        <h4 style="margin:0;">API Keys</h4>
+        <label>OpenAI <input type="password" name="openai" /></label>
+        <label>Anthropic <input type="password" name="anthropic" /></label>
+        <label>Groq <input type="password" name="groq" /></label>
+        <label>Gemini <input type="password" name="gemini" /></label>
+        <button type="submit" class="secondary">Salvar Chaves</button>
+      </form>
     </div>
   </div>
 

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -21,6 +21,51 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   let pendingMode = 'video';
   let currentChatClientId = null;
 
+  const configForm = document.getElementById('configForm');
+  const keyForm = document.getElementById('keyForm');
+
+  async function postAdmin(path, data) {
+    const key = prompt('Chave admin?');
+    await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+      body: JSON.stringify(data)
+    });
+  }
+
+  if (configForm) {
+    configForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(configForm);
+      const data = {
+        provider: fd.get('provider'),
+        parameters: {
+          max_output_tokens: Number(fd.get('max_output_tokens')),
+          temperature: Number(fd.get('temperature')),
+          top_p: Number(fd.get('top_p'))
+        },
+        prompt: fd.get('prompt')
+      };
+      await postAdmin('/admin/config', data);
+      alert('Configuração salva');
+    });
+  }
+
+  if (keyForm) {
+    keyForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(keyForm);
+      const data = {
+        openai: fd.get('openai'),
+        anthropic: fd.get('anthropic'),
+        groq: fd.get('groq'),
+        gemini: fd.get('gemini')
+      };
+      await postAdmin('/admin/keys', data);
+      alert('Chaves salvas');
+    });
+  }
+
   function setInfo(text) { info.textContent = text; }
 
   let pendingClientId = null;
@@ -67,7 +112,13 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   // Chat
   function appendMessage(sender, text) {
     const div = document.createElement('div');
-    div.textContent = `${sender}: ${text}`;
+    div.classList.add('msg');
+    let type = 'client';
+    if (sender === 'Você') type = 'lawyer';
+    else if (sender === 'IA') type = 'ai';
+    else if (sender === 'Erro IA') type = 'error';
+    div.classList.add(type);
+    div.innerHTML = `<strong>${sender}:</strong> ${text}`;
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
   }
@@ -85,10 +136,34 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     if (e.key === 'Enter') { e.preventDefault(); sendChat(); }
   });
 
+  async function handleAiReply(clientId, msg) {
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: clientId, message: msg })
+      });
+      const data = await res.json();
+      if (res.ok && data.reply) {
+        appendMessage('IA', data.reply);
+        socket.emit('chat-message', { targetId: clientId, message: data.reply });
+      } else {
+        let err = data.error || 'erro_desconhecido';
+        if (err === 'missing_api_key') err = 'Chave de API ausente';
+        else if (err === 'limit_reached') err = 'Limite de uso atingido';
+        appendMessage('Erro IA', err);
+      }
+    } catch (e) {
+      appendMessage('Erro IA', 'Falha ao contatar provedor');
+      console.error('AI error', e);
+    }
+  }
+
   socket.on('chat-message', ({ from, message }) => {
     currentChatClientId = from;
     appendMessage('Cliente', message);
     sendBtn.disabled = false;
+    handleAiReply(from, message);
   });
 
   socket.on('webrtc-offer', async ({ from, sdp }) => {
@@ -173,4 +248,13 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
   }
+
+  document.querySelectorAll('.quick-reply').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const msg = btn.dataset.msg;
+      if (!msg || !currentChatClientId) return;
+      appendMessage('Você', msg);
+      socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
+    });
+  });
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -135,6 +135,14 @@ h2::after {
   flex-wrap: wrap;
 }
 
+.quick-replies { 
+  margin-bottom: 8px; 
+} 
+.quick-replies button { 
+  padding: 6px 8px; 
+  font-size: 12px; 
+} 
+
 button.primary {
     background: linear-gradient(90deg, #22c55e, #16a34a);
     color: #052e16;
@@ -255,26 +263,44 @@ button.danger { background: #ef4444; color: white; }
   margin-bottom: 8px;
 }
 
-.chat-messages .msg {
-  margin-bottom: 4px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  white-space: pre-wrap;
-}
+.chat-messages .msg { 
+  margin-bottom: 4px; 
+  padding: 6px 8px; 
+  border-radius: 6px; 
+  white-space: pre-wrap; 
+} 
 
-.chat-messages .msg.user {
-  background: #1e293b;
-  text-align: right;
-}
+.chat-messages .msg.user { 
+  background: #1e293b; 
+  text-align: right; 
+} 
 
-.chat-messages .msg.assistant {
-  background: #334155;
-}
+.chat-messages .msg.assistant { 
+  background: #334155; 
+} 
 
-.chat-input {
-  display: flex;
-  gap: 8px;
-}
+.chat-messages .msg.lawyer { 
+  background: #1e293b; 
+  text-align: right; 
+} 
+
+.chat-messages .msg.client { 
+  background: #334155; 
+} 
+
+.chat-messages .msg.ai { 
+  background: #475569; 
+  font-style: italic; 
+} 
+
+.chat-messages .msg.error { 
+  background: #7f1d1d; 
+} 
+
+.chat-input { 
+  display: flex; 
+  gap: 8px; 
+} 
 
 .chat-input input {
   flex: 1;
@@ -285,7 +311,27 @@ button.danger { background: #ef4444; color: white; }
   color: var(--text);
 }
 
-.chat-input button { flex-shrink: 0; }
+.chat-input button { flex-shrink: 0; } 
+
+#configForm label,
+#keyForm label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+}
+
+#configForm select,
+#configForm input,
+#configForm textarea,
+#keyForm input {
+  margin-top: 2px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #0b1224;
+  color: var(--text);
+}
 
 @media (max-width: 900px) {
   .hero { grid-template-columns: 1fr; }

--- a/server.js
+++ b/server.js
@@ -44,18 +44,19 @@ const adminConfig = {
   provider: 'openai',
   parameters: {
     model: 'gpt-4o-mini',
-    max_output_tokens: 500,
+    max_output_tokens: 200,
     temperature: 0.7,
     top_p: 1,
     stop_sequences: []
   },
-  prompt: 'Você é uma secretária jurídica especialista. Conduza a triagem em blocos e responda em português.',
+  prompt: 'Você é um advogado profissional. Responda de forma curta, clara e educada em português.',
   limits: { maxMessages: 20, maxChars: 1000 },
   features: { upload: false, ocr: false },
   apiKeys: {
     openai: process.env.OPENAI_API_KEY || '',
     anthropic: process.env.ANTHROPIC_API_KEY || '',
-    groq: process.env.GROQ_API_KEY || ''
+    groq: process.env.GROQ_API_KEY || '',
+    gemini: process.env.GEMINI_API_KEY || ''
   }
 };
 
@@ -86,24 +87,28 @@ app.post('/api/chat', chatLimiter, async (req, res) => {
   if (session.count >= adminConfig.limits.maxMessages) {
     return res.status(400).json({ error: 'limit_reached' });
   }
+  const apiKey = adminConfig.apiKeys[adminConfig.provider];
+  if (!apiKey) {
+    return res.status(400).json({ error: 'missing_api_key' });
+  }
   session.count++;
   session.messages.push({ role: 'user', content: message });
   sessions[sessionId] = session;
   try {
     const aiMessages = [{ role: 'system', content: adminConfig.prompt }, ...session.messages];
-    const reply = await generate(adminConfig.provider, adminConfig.apiKeys[adminConfig.provider], aiMessages, adminConfig.parameters);
+    const reply = await generate(adminConfig.provider, apiKey, aiMessages, adminConfig.parameters);
     session.messages.push({ role: 'assistant', content: reply });
     res.json({ reply });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: 'provider_error' });
+    res.status(500).json({ error: e.message || 'provider_error' });
   }
 });
 
 const adminKey = process.env.ADMIN_KEY || 'secret';
 
 const configSchema = z.object({
-  provider: z.enum(['openai', 'anthropic', 'groq']).optional(),
+  provider: z.enum(['openai', 'anthropic', 'groq', 'gemini']).optional(),
   parameters: z.object({
     model: z.string().optional(),
     max_output_tokens: z.number().optional(),
@@ -119,7 +124,8 @@ const configSchema = z.object({
 const keySchema = z.object({
   openai: z.string().optional(),
   anthropic: z.string().optional(),
-  groq: z.string().optional()
+  groq: z.string().optional(),
+  gemini: z.string().optional()
 });
 
 app.use('/admin', (req, res, next) => {


### PR DESCRIPTION
## Summary
- support Gemini alongside existing AI providers and store its API key
- surface missing key or quota errors in the lawyer chat and style messages by sender
- refine AI settings panel and chat layout for clearer contact vs assistant messages

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9b82352ec832dacbe4e4b589bd3ae