### PR TITLE
feat: simplify AI config and add report generation

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -70,10 +70,37 @@ async function groqGenerate(apiKey, messages, params) {
   return '';
 }
 
+async function geminiGenerate(apiKey, messages, params) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${params.model || 'gemini-pro'}:generateContent?key=${apiKey}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: messages.map(m => ({
+        role: m.role === 'assistant' ? 'model' : m.role,
+        parts: [{ text: m.content }]
+      })),
+      generationConfig: {
+        maxOutputTokens: params.max_output_tokens,
+        temperature: params.temperature,
+        topP: params.top_p,
+        stopSequences: params.stop_sequences
+      }
+    })
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error && data.error.message ? data.error.message : 'gemini_error');
+  }
+  return data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text || '';
+}
+
 async function generate(provider, apiKey, messages, params) {
   switch (provider) {
     case 'anthropic':
       return anthropicGenerate(apiKey, messages, params);
+    case 'gemini':
+      return geminiGenerate(apiKey, messages, params);
     case 'groq':
       return groqGenerate(apiKey, messages, params);
     case 'openai':

--- a/public/admin.html
+++ b/public/admin.html
@@ -12,6 +12,7 @@
         <option value="openai">OpenAI</option>
         <option value="anthropic">Anthropic</option>
         <option value="groq">Groq</option>
+        <option value="gemini">Gemini</option>
       </select>
     </label>
     <label>Max tokens <input type="number" name="max_output_tokens" /></label>
@@ -25,6 +26,7 @@
     <label>OpenAI <input type="password" name="openai" /></label>
     <label>Anthropic <input type="password" name="anthropic" /></label>
     <label>Groq <input type="password" name="groq" /></label>
+    <label>Gemini <input type="password" name="gemini" /></label>
     <button type="submit">Salvar chaves</button>
   </form>
   <script src="/admin.js"></script>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,8 +1,7 @@
 async function post(path, data) {
-  const key = prompt('Chave admin?');
   await fetch(path, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
   });
 }
@@ -29,7 +28,8 @@ document.getElementById('keyForm').addEventListener('submit', async (e) => {
   const data = {
     openai: fd.get('openai'),
     anthropic: fd.get('anthropic'),
-    groq: fd.get('groq')
+    groq: fd.get('groq'),
+    gemini: fd.get('gemini')
   };
   await post('/admin/keys', data);
   alert('Chaves salvas');

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -42,10 +42,58 @@
     <div class="panel" style="margin-top:14px;" id="chatPanel">
       <h3 style="margin-top:0;">Chat de Texto</h3>
       <div id="messages" class="chat-messages"></div>
+      <div id="quickReplies" class="actions quick-replies">
+        <button class="secondary quick-reply" data-msg="Olá, como posso ajudar?">Saudação</button>
+        <button class="secondary quick-reply" data-msg="Poderia fornecer mais detalhes?">Mais detalhes</button>
+        <button class="secondary quick-reply" data-msg="Vamos agendar uma reunião para discutir melhor?">Agendar reunião</button>
+        <button class="secondary quick-reply" data-msg="Estou analisando seu caso e retornarei em breve.">Analisar</button>
+      </div>
       <div class="chat-input">
         <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
         <button id="sendBtn" class="primary" disabled>Enviar</button>
       </div>
+    </div>
+    <div class="panel" style="margin-top:14px;">
+      <h3 style="margin-top:0;">Configurações de IA</h3>
+      <form id="configForm" class="form-grid">
+        <div class="provider-field">
+          <span>Provedor</span>
+          <div class="provider-options">
+            <label class="provider-option"><input type="radio" name="provider" value="openai" checked/> OpenAI</label>
+            <label class="provider-option"><input type="radio" name="provider" value="anthropic"/> Anthropic</label>
+            <label class="provider-option"><input type="radio" name="provider" value="groq"/> Groq</label>
+            <label class="provider-option"><input type="radio" name="provider" value="gemini"/> Gemini</label>
+          </div>
+        </div>
+        <label>Max tokens <input type="number" name="max_output_tokens" value="200" /></label>
+        <label>Temperature <input type="number" step="0.1" name="temperature" value="0.7" /></label>
+        <label>Top P <input type="number" step="0.1" name="top_p" value="1" /></label>
+        <label>Prompt<br/>
+          <textarea name="prompt" rows="3">Você é um advogado virtual do escritório. Use frases curtas e educadas em português. Faça perguntas para entender o problema do cliente e identifique documentos importantes para cada caso. Se o assunto for usucapião, pergunte se prefere via extrajudicial ou judicial e se deseja saber o custo de cada opção, pesquisando nas tabelas de custas do TJMG quando solicitado. Quando tiver informações suficientes, finalize a conversa e inclua uma linha começando com "RELATORIO:" resumindo os dados para o advogado.</textarea>
+        </label>
+        <button type="submit" class="primary">Salvar Config</button>
+      </form>
+      <form id="keyForm" class="form-grid" style="margin-top:12px;">
+        <h4 style="margin:0;">API Keys</h4>
+        <label>OpenAI <input type="password" name="openai" /></label>
+        <label>Anthropic <input type="password" name="anthropic" /></label>
+        <label>Groq <input type="password" name="groq" /></label>
+        <label>Gemini <input type="password" name="gemini" /></label>
+        <button type="submit" class="secondary">Salvar Chaves</button>
+      </form>
+    </div>
+    <div class="panel" style="margin-top:14px;" id="aiPanel">
+      <h3 style="margin-top:0;">Assistente de IA</h3>
+      <div id="aiMessages" class="chat-messages"></div>
+      <div class="chat-input">
+        <input id="aiInput" type="text" placeholder="Pergunte à IA" />
+        <button id="aiSendBtn" class="secondary">Enviar</button>
+      </div>
+    </div>
+    <div class="panel" style="margin-top:14px;" id="reportsPanel">
+      <h3 style="margin-top:0;">Relatórios</h3>
+      <button id="refreshReports" class="secondary">Atualizar</button>
+      <ul id="reportsList" class="reports-list"></ul>
     </div>
   </div>
 

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -11,6 +11,11 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const messages = document.getElementById('messages');
   const chatInput = document.getElementById('chatInput');
   const sendBtn = document.getElementById('sendBtn');
+  const aiMessages = document.getElementById('aiMessages');
+  const aiInput = document.getElementById('aiInput');
+  const aiSendBtn = document.getElementById('aiSendBtn');
+  const reportsList = document.getElementById('reportsList');
+  const refreshReports = document.getElementById('refreshReports');
 
   const socket = io();
   socket.emit('identify', { role: 'lawyer' });
@@ -20,6 +25,50 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   let currentClientId = null;
   let pendingMode = 'video';
   let currentChatClientId = null;
+
+  const configForm = document.getElementById('configForm');
+  const keyForm = document.getElementById('keyForm');
+
+  async function postAdmin(path, data) {
+    await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+  if (configForm) {
+    configForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(configForm);
+      const data = {
+        provider: fd.get('provider'),
+        parameters: {
+          max_output_tokens: Number(fd.get('max_output_tokens')),
+          temperature: Number(fd.get('temperature')),
+          top_p: Number(fd.get('top_p'))
+        },
+        prompt: fd.get('prompt')
+      };
+      await postAdmin('/admin/config', data);
+      alert('Configuração salva');
+    });
+  }
+
+  if (keyForm) {
+    keyForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(keyForm);
+      const data = {
+        openai: fd.get('openai'),
+        anthropic: fd.get('anthropic'),
+        groq: fd.get('groq'),
+        gemini: fd.get('gemini')
+      };
+      await postAdmin('/admin/keys', data);
+      alert('Chaves salvas');
+    });
+  }
 
   function setInfo(text) { info.textContent = text; }
 
@@ -65,17 +114,18 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   });
 
   // Chat
-  function appendMessage(sender, text) {
+  function appendMessage(container, role, text) {
     const div = document.createElement('div');
-    div.textContent = `${sender}: ${text}`;
-    messages.appendChild(div);
-    messages.scrollTop = messages.scrollHeight;
+    div.className = `msg ${role}`;
+    div.textContent = text;
+    container.appendChild(div);
+    container.scrollTop = container.scrollHeight;
   }
 
   function sendChat() {
     const msg = chatInput.value.trim();
     if (!msg || !currentChatClientId) return;
-    appendMessage('Você', msg);
+    appendMessage(messages, 'you', `Você: ${msg}`);
     socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
     chatInput.value = '';
   }
@@ -85,10 +135,35 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     if (e.key === 'Enter') { e.preventDefault(); sendChat(); }
   });
 
+  async function askAi(sessionId, msg) {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, message: msg })
+    });
+    return res.json();
+  }
+
   socket.on('chat-message', ({ from, message }) => {
     currentChatClientId = from;
-    appendMessage('Cliente', message);
+    appendMessage(messages, 'client', `Cliente: ${message}`);
     sendBtn.disabled = false;
+    askAi(from, message).then(data => {
+      if (data.reply) {
+        appendMessage(aiMessages, 'ai', `Sugestão: ${data.reply}`);
+      } else if (data.error) {
+        const map = {
+          missing_api_key: 'Chave de API ausente.',
+          limit_reached: 'Limite de uso atingido.',
+          msg_too_long: 'Mensagem muito longa.',
+          session_closed: 'Sessão encerrada.'
+        };
+        appendMessage(aiMessages, 'error', `Erro IA: ${map[data.error] || data.message || data.error}`);
+      }
+    }).catch(e => {
+      console.error('AI error', e);
+      appendMessage(aiMessages, 'error', 'Erro IA inesperado.');
+    });
   });
 
   socket.on('webrtc-offer', async ({ from, sdp }) => {
@@ -172,5 +247,64 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   // Aviso de contexto inseguro
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
+  }
+
+  document.querySelectorAll('.quick-reply').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const msg = btn.dataset.msg;
+      if (!msg || !currentChatClientId) return;
+      appendMessage(messages, 'you', `Você: ${msg}`);
+      socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
+    });
+  });
+
+  function sendAi() {
+    const msg = aiInput.value.trim();
+    if (!msg) return;
+    appendMessage(aiMessages, 'you', `Você: ${msg}`);
+    aiInput.value = '';
+    askAi('lawyer-assistant', msg).then(data => {
+      if (data.reply) {
+        appendMessage(aiMessages, 'ai', `IA: ${data.reply}`);
+      } else if (data.error) {
+        const map = {
+          missing_api_key: 'Chave de API ausente.',
+          limit_reached: 'Limite de uso atingido.',
+          msg_too_long: 'Mensagem muito longa.',
+          session_closed: 'Sessão encerrada.'
+        };
+        appendMessage(aiMessages, 'error', `Erro IA: ${map[data.error] || data.message || data.error}`);
+      }
+    }).catch(e => {
+      console.error('AI error', e);
+      appendMessage(aiMessages, 'error', 'Erro IA inesperado.');
+    });
+  }
+
+  if (aiSendBtn) {
+    aiSendBtn.addEventListener('click', sendAi);
+    aiInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') { e.preventDefault(); sendAi(); } });
+  }
+
+  async function loadReports() {
+    try {
+      const res = await fetch('/admin/reports');
+      const list = await res.json();
+      if (!reportsList) return;
+      reportsList.innerHTML = '';
+      list.forEach(r => {
+        const li = document.createElement('li');
+        const date = new Date(r.timestamp).toLocaleString();
+        li.textContent = `${date}: ${r.text}`;
+        reportsList.appendChild(li);
+      });
+    } catch (e) {
+      console.error('report load error', e);
+    }
+  }
+
+  if (refreshReports) {
+    refreshReports.addEventListener('click', loadReports);
+    loadReports();
   }
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -135,6 +135,65 @@ h2::after {
   flex-wrap: wrap;
 }
 
+.quick-replies {
+  margin-bottom: 8px;
+}
+.quick-replies button {
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  margin-top: 4px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #0b1224;
+  color: var(--text);
+}
+
+.provider-options {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.provider-option {
+  background: #1f2937;
+  padding: 4px 8px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.provider-option input { margin: 0; }
+
+.provider-field { display: flex; flex-direction: column; gap: 4px; }
+.provider-field span { font-size: 14px; }
+
+.reports-list {
+  list-style: disc;
+  padding-left: 20px;
+  max-height: 200px;
+  overflow-y: auto;
+  margin-top: 8px;
+}
+
+.reports-list li { margin-bottom: 6px; }
+
 button.primary {
     background: linear-gradient(90deg, #22c55e, #16a34a);
     color: #052e16;
@@ -262,13 +321,25 @@ button.danger { background: #ef4444; color: white; }
   white-space: pre-wrap;
 }
 
-.chat-messages .msg.user {
+.chat-messages .msg.you {
   background: #1e293b;
   text-align: right;
 }
 
-.chat-messages .msg.assistant {
+.chat-messages .msg.client {
   background: #334155;
+}
+
+.chat-messages .msg.ai {
+  background: #1e293b;
+  border-left: 2px solid var(--accent);
+  font-style: italic;
+}
+
+.chat-messages .msg.error {
+  background: #7f1d1d;
+  color: #fecaca;
+  text-align: center;
 }
 
 .chat-input {

--- a/server.js
+++ b/server.js
@@ -44,22 +44,24 @@ const adminConfig = {
   provider: 'openai',
   parameters: {
     model: 'gpt-4o-mini',
-    max_output_tokens: 500,
+    max_output_tokens: 200,
     temperature: 0.7,
     top_p: 1,
     stop_sequences: []
   },
-  prompt: 'Você é uma secretária jurídica especialista. Conduza a triagem em blocos e responda em português.',
+  prompt: 'Você é um advogado virtual do escritório. Use frases curtas e educadas em português. Faça perguntas para entender o problema do cliente e identifique documentos importantes para cada caso. Se o assunto for usucapião, pergunte se prefere via extrajudicial ou judicial e se deseja saber o custo de cada opção, pesquisando nas tabelas de custas do TJMG quando solicitado. Quando tiver informações suficientes, finalize a conversa e inclua uma linha começando com "RELATORIO:" resumindo os dados para o advogado.',
   limits: { maxMessages: 20, maxChars: 1000 },
   features: { upload: false, ocr: false },
   apiKeys: {
     openai: process.env.OPENAI_API_KEY || '',
     anthropic: process.env.ANTHROPIC_API_KEY || '',
-    groq: process.env.GROQ_API_KEY || ''
+    groq: process.env.GROQ_API_KEY || '',
+    gemini: process.env.GEMINI_API_KEY || ''
   }
 };
 
 const sessions = {};
+const reports = [];
 
 // Endpoint simples para formulário de contato
 app.post('/contact', (req, res) => {
@@ -82,28 +84,41 @@ app.post('/api/chat', chatLimiter, async (req, res) => {
   if (message.length > adminConfig.limits.maxChars) {
     return res.status(400).json({ error: 'msg_too_long' });
   }
-  const session = sessions[sessionId] || { count: 0, messages: [] };
+  const session = sessions[sessionId] || { count: 0, messages: [], done: false };
+  if (session.done) {
+    return res.status(400).json({ error: 'session_closed' });
+  }
   if (session.count >= adminConfig.limits.maxMessages) {
     return res.status(400).json({ error: 'limit_reached' });
   }
   session.count++;
   session.messages.push({ role: 'user', content: message });
   sessions[sessionId] = session;
+  const apiKey = adminConfig.apiKeys[adminConfig.provider];
+  if (!apiKey) {
+    return res.status(400).json({ error: 'missing_api_key' });
+  }
   try {
     const aiMessages = [{ role: 'system', content: adminConfig.prompt }, ...session.messages];
-    const reply = await generate(adminConfig.provider, adminConfig.apiKeys[adminConfig.provider], aiMessages, adminConfig.parameters);
+    const reply = await generate(adminConfig.provider, apiKey, aiMessages, adminConfig.parameters);
     session.messages.push({ role: 'assistant', content: reply });
-    res.json({ reply });
+    let clientReply = reply;
+    const idx = reply.indexOf('RELATORIO:');
+    if (idx !== -1) {
+      clientReply = reply.slice(0, idx).trim();
+      const reportText = reply.slice(idx + 'RELATORIO:'.length).trim();
+      reports.push({ sessionId, text: reportText, timestamp: Date.now() });
+      session.done = true;
+    }
+    res.json({ reply: clientReply });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: 'provider_error' });
+    res.status(500).json({ error: 'provider_error', message: e.message });
   }
 });
 
-const adminKey = process.env.ADMIN_KEY || 'secret';
-
 const configSchema = z.object({
-  provider: z.enum(['openai', 'anthropic', 'groq']).optional(),
+  provider: z.enum(['openai', 'anthropic', 'groq', 'gemini']).optional(),
   parameters: z.object({
     model: z.string().optional(),
     max_output_tokens: z.number().optional(),
@@ -119,12 +134,8 @@ const configSchema = z.object({
 const keySchema = z.object({
   openai: z.string().optional(),
   anthropic: z.string().optional(),
-  groq: z.string().optional()
-});
-
-app.use('/admin', (req, res, next) => {
-  if (req.headers['x-admin-key'] !== adminKey) return res.sendStatus(401);
-  next();
+  groq: z.string().optional(),
+  gemini: z.string().optional()
 });
 
 app.get('/admin/config', (req, res) => {
@@ -145,6 +156,10 @@ app.post('/admin/keys', (req, res) => {
   if (!parsed.success) return res.status(400).json({ error: 'invalid_keys' });
   adminConfig.apiKeys = { ...adminConfig.apiKeys, ...parsed.data };
   res.json({ ok: true });
+});
+
+app.get('/admin/reports', (req, res) => {
+  res.json(reports);
 });
 
 let lawyerSocket = null; // socket do advogado


### PR DESCRIPTION
## Summary
- remove admin key prompts and allow direct AI provider/key updates
- refine AI prompt and provider selection styling; add report panel for summaries
- capture final AI reports server-side and expose through new endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9b82352ec832dacbe4e4b589bd3ae