### PR TITLE
feat: refine ai controls and remove admin key

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -70,10 +70,37 @@ async function groqGenerate(apiKey, messages, params) {
   return '';
 }
 
+async function geminiGenerate(apiKey, messages, params) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${params.model || 'gemini-pro'}:generateContent?key=${apiKey}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: messages.map(m => ({
+        role: m.role === 'assistant' ? 'model' : m.role,
+        parts: [{ text: m.content }]
+      })),
+      generationConfig: {
+        maxOutputTokens: params.max_output_tokens,
+        temperature: params.temperature,
+        topP: params.top_p,
+        stopSequences: params.stop_sequences
+      }
+    })
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error && data.error.message ? data.error.message : 'gemini_error');
+  }
+  return data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text || '';
+}
+
 async function generate(provider, apiKey, messages, params) {
   switch (provider) {
     case 'anthropic':
       return anthropicGenerate(apiKey, messages, params);
+    case 'gemini':
+      return geminiGenerate(apiKey, messages, params);
     case 'groq':
       return groqGenerate(apiKey, messages, params);
     case 'openai':

--- a/public/admin.html
+++ b/public/admin.html
@@ -7,13 +7,14 @@
 <body>
   <h1>Painel Administrativo</h1>
   <form id="configForm">
-    <label>Provedor
-      <select name="provider">
-        <option value="openai">OpenAI</option>
-        <option value="anthropic">Anthropic</option>
-        <option value="groq">Groq</option>
-      </select>
-    </label>
+      <label>Provedor
+        <select name="provider">
+          <option value="openai">OpenAI</option>
+          <option value="anthropic">Anthropic</option>
+          <option value="groq">Groq</option>
+          <option value="gemini">Gemini</option>
+        </select>
+      </label>
     <label>Max tokens <input type="number" name="max_output_tokens" /></label>
     <label>Temperature <input type="number" step="0.1" name="temperature" /></label>
     <label>Top P <input type="number" step="0.1" name="top_p" /></label>
@@ -24,7 +25,8 @@
     <h2>API Keys</h2>
     <label>OpenAI <input type="password" name="openai" /></label>
     <label>Anthropic <input type="password" name="anthropic" /></label>
-    <label>Groq <input type="password" name="groq" /></label>
+      <label>Groq <input type="password" name="groq" /></label>
+      <label>Gemini <input type="password" name="gemini" /></label>
     <button type="submit">Salvar chaves</button>
   </form>
   <script src="/admin.js"></script>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,8 +1,7 @@
 async function post(path, data) {
-  const key = prompt('Chave admin?');
   await fetch(path, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
   });
 }
@@ -29,7 +28,8 @@ document.getElementById('keyForm').addEventListener('submit', async (e) => {
   const data = {
     openai: fd.get('openai'),
     anthropic: fd.get('anthropic'),
-    groq: fd.get('groq')
+    groq: fd.get('groq'),
+    gemini: fd.get('gemini')
   };
   await post('/admin/keys', data);
   alert('Chaves salvas');

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -42,11 +42,55 @@
     <div class="panel" style="margin-top:14px;" id="chatPanel">
       <h3 style="margin-top:0;">Chat de Texto</h3>
       <div id="messages" class="chat-messages"></div>
+      <div id="quickReplies" class="actions quick-replies">
+        <button class="secondary quick-reply" data-msg="Olá, como posso ajudar?">Saudação</button>
+        <button class="secondary quick-reply" data-msg="Poderia fornecer mais detalhes?">Mais detalhes</button>
+        <button class="secondary quick-reply" data-msg="Vamos agendar uma reunião para discutir melhor?">Agendar reunião</button>
+        <button class="secondary quick-reply" data-msg="Estou analisando seu caso e retornarei em breve.">Analisar</button>
+      </div>
       <div class="chat-input">
         <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
         <button id="sendBtn" class="primary" disabled>Enviar</button>
       </div>
     </div>
+    <div class="panel" style="margin-top:14px;">
+      <h3 style="margin-top:0;">Configurações de IA</h3>
+        <form id="configForm" class="form-grid">
+          <div class="provider-options">
+            <label class="provider-option"><input type="radio" name="provider" value="openai" checked><span>OpenAI</span></label>
+            <label class="provider-option"><input type="radio" name="provider" value="anthropic"><span>Anthropic</span></label>
+            <label class="provider-option"><input type="radio" name="provider" value="groq"><span>Groq</span></label>
+            <label class="provider-option"><input type="radio" name="provider" value="gemini"><span>Gemini</span></label>
+          </div>
+          <label>Max tokens <input type="number" name="max_output_tokens" value="200" /></label>
+          <label>Temperature <input type="number" step="0.1" name="temperature" value="0.7" /></label>
+          <label>Top P <input type="number" step="0.1" name="top_p" value="1" /></label>
+          <label>Prompt<br/>
+            <textarea name="prompt" rows="3">Você é um advogado virtual. Converse em poucas palavras e em português. Pergunte qual é o problema do cliente e quais documentos possui. Se o tema for usucapião, questione se prefere via extrajudicial ou judicial e se deseja saber os custos de ambas, pesquisando nas tabelas de custas do TJMG. Quando tiver informações suficientes, encerre cordialmente e produza um relatório. Responda sempre em JSON como {"reply":"texto","done":bool,"report":"resumo"} e só inclua report quando done for true.</textarea>
+          </label>
+          <button type="submit" class="primary">Salvar Config</button>
+        </form>
+      <form id="keyForm" class="form-grid" style="margin-top:12px;">
+        <h4 style="margin:0;">API Keys</h4>
+        <label>OpenAI <input type="password" name="openai" /></label>
+        <label>Anthropic <input type="password" name="anthropic" /></label>
+        <label>Groq <input type="password" name="groq" /></label>
+        <label>Gemini <input type="password" name="gemini" /></label>
+        <button type="submit" class="secondary">Salvar Chaves</button>
+      </form>
+    </div>
+      <div class="panel" style="margin-top:14px;" id="aiPanel">
+      <h3 style="margin-top:0;">Assistente de IA</h3>
+      <div id="aiMessages" class="chat-messages"></div>
+        <div class="chat-input">
+          <input id="aiInput" type="text" placeholder="Pergunte à IA" />
+          <button id="aiSendBtn" class="secondary">Enviar</button>
+        </div>
+      </div>
+      <div class="panel" style="margin-top:14px; display:none;" id="reportPanel">
+        <h3 style="margin-top:0;">Relatórios</h3>
+        <div id="reports" class="reports"></div>
+      </div>
   </div>
 
   <div class="incoming" id="incoming">

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -11,6 +11,11 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const messages = document.getElementById('messages');
   const chatInput = document.getElementById('chatInput');
   const sendBtn = document.getElementById('sendBtn');
+    const aiMessages = document.getElementById('aiMessages');
+    const aiInput = document.getElementById('aiInput');
+    const aiSendBtn = document.getElementById('aiSendBtn');
+    const reportPanel = document.getElementById('reportPanel');
+    const reports = document.getElementById('reports');
 
   const socket = io();
   socket.emit('identify', { role: 'lawyer' });
@@ -21,7 +26,59 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   let pendingMode = 'video';
   let currentChatClientId = null;
 
-  function setInfo(text) { info.textContent = text; }
+  const configForm = document.getElementById('configForm');
+  const keyForm = document.getElementById('keyForm');
+
+    async function postAdmin(path, data) {
+      await fetch(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+    }
+
+  if (configForm) {
+    configForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(configForm);
+      const data = {
+        provider: fd.get('provider'),
+        parameters: {
+          max_output_tokens: Number(fd.get('max_output_tokens')),
+          temperature: Number(fd.get('temperature')),
+          top_p: Number(fd.get('top_p'))
+        },
+        prompt: fd.get('prompt')
+      };
+      await postAdmin('/admin/config', data);
+      alert('Configuração salva');
+    });
+  }
+
+  if (keyForm) {
+    keyForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(keyForm);
+      const data = {
+        openai: fd.get('openai'),
+        anthropic: fd.get('anthropic'),
+        groq: fd.get('groq'),
+        gemini: fd.get('gemini')
+      };
+      await postAdmin('/admin/keys', data);
+      alert('Chaves salvas');
+    });
+  }
+
+    function setInfo(text) { info.textContent = text; }
+
+    function appendReport(text) {
+      const div = document.createElement('div');
+      div.className = 'report';
+      div.textContent = text;
+      reports.appendChild(div);
+      reportPanel.style.display = 'block';
+    }
 
   let pendingClientId = null;
   socket.on('incoming-call', ({ clientId, mode }) => {
@@ -65,17 +122,18 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   });
 
   // Chat
-  function appendMessage(sender, text) {
+  function appendMessage(container, role, text) {
     const div = document.createElement('div');
-    div.textContent = `${sender}: ${text}`;
-    messages.appendChild(div);
-    messages.scrollTop = messages.scrollHeight;
+    div.className = `msg ${role}`;
+    div.textContent = text;
+    container.appendChild(div);
+    container.scrollTop = container.scrollHeight;
   }
 
   function sendChat() {
     const msg = chatInput.value.trim();
     if (!msg || !currentChatClientId) return;
-    appendMessage('Você', msg);
+    appendMessage(messages, 'you', `Você: ${msg}`);
     socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
     chatInput.value = '';
   }
@@ -85,11 +143,42 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     if (e.key === 'Enter') { e.preventDefault(); sendChat(); }
   });
 
+  async function askAi(sessionId, msg) {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, message: msg })
+    });
+    return res.json();
+  }
+
   socket.on('chat-message', ({ from, message }) => {
     currentChatClientId = from;
-    appendMessage('Cliente', message);
+    appendMessage(messages, 'client', `Cliente: ${message}`);
     sendBtn.disabled = false;
-  });
+      askAi(from, message).then(data => {
+        if (data.reply) {
+          appendMessage(aiMessages, 'ai', `Sugestão: ${data.reply}`);
+        }
+        if (data.report) {
+          appendReport(data.report);
+        }
+        if (data.done) {
+          appendMessage(aiMessages, 'ai', 'Conversa concluída.');
+        }
+        if (data.error) {
+          const map = {
+            missing_api_key: 'Chave de API ausente.',
+            limit_reached: 'Limite de uso atingido.',
+            msg_too_long: 'Mensagem muito longa.'
+          };
+          appendMessage(aiMessages, 'error', `Erro IA: ${map[data.error] || data.message || data.error}`);
+        }
+      }).catch(e => {
+        console.error('AI error', e);
+        appendMessage(aiMessages, 'error', 'Erro IA inesperado.');
+      });
+    });
 
   socket.on('webrtc-offer', async ({ from, sdp }) => {
     if (!pc || from !== currentClientId) return;
@@ -172,5 +261,41 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   // Aviso de contexto inseguro
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
+  }
+
+  document.querySelectorAll('.quick-reply').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const msg = btn.dataset.msg;
+      if (!msg || !currentChatClientId) return;
+      appendMessage(messages, 'you', `Você: ${msg}`);
+      socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
+    });
+  });
+
+  function sendAi() {
+    const msg = aiInput.value.trim();
+    if (!msg) return;
+    appendMessage(aiMessages, 'you', `Você: ${msg}`);
+    aiInput.value = '';
+    askAi('lawyer-assistant', msg).then(data => {
+      if (data.reply) {
+        appendMessage(aiMessages, 'ai', `IA: ${data.reply}`);
+      } else if (data.error) {
+        const map = {
+          missing_api_key: 'Chave de API ausente.',
+          limit_reached: 'Limite de uso atingido.',
+          msg_too_long: 'Mensagem muito longa.'
+        };
+        appendMessage(aiMessages, 'error', `Erro IA: ${map[data.error] || data.message || data.error}`);
+      }
+    }).catch(e => {
+      console.error('AI error', e);
+      appendMessage(aiMessages, 'error', 'Erro IA inesperado.');
+    });
+  }
+
+  if (aiSendBtn) {
+    aiSendBtn.addEventListener('click', sendAi);
+    aiInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') { e.preventDefault(); sendAi(); } });
   }
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -135,6 +135,69 @@ h2::after {
   flex-wrap: wrap;
 }
 
+.quick-replies {
+  margin-bottom: 8px;
+}
+.quick-replies button {
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+.form-grid input,
+.form-grid select,
+  .form-grid textarea {
+    margin-top: 4px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: #0b1224;
+    color: var(--text);
+  }
+
+  .provider-options {
+    display: flex;
+    gap: 8px;
+  }
+  .provider-option {
+    flex: 1;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 6px;
+    padding: 6px 0;
+    text-align: center;
+    background: #0b1224;
+    cursor: pointer;
+  }
+  .provider-option input {
+    display: none;
+  }
+  .provider-option input:checked + span {
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  .reports {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .report {
+    padding: 8px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 6px;
+    background: #0b1224;
+    font-size: 14px;
+  }
+
 button.primary {
     background: linear-gradient(90deg, #22c55e, #16a34a);
     color: #052e16;
@@ -262,13 +325,25 @@ button.danger { background: #ef4444; color: white; }
   white-space: pre-wrap;
 }
 
-.chat-messages .msg.user {
+.chat-messages .msg.you {
   background: #1e293b;
   text-align: right;
 }
 
-.chat-messages .msg.assistant {
+.chat-messages .msg.client {
   background: #334155;
+}
+
+.chat-messages .msg.ai {
+  background: #1e293b;
+  border-left: 2px solid var(--accent);
+  font-style: italic;
+}
+
+.chat-messages .msg.error {
+  background: #7f1d1d;
+  color: #fecaca;
+  text-align: center;
 }
 
 .chat-input {

--- a/server.js
+++ b/server.js
@@ -44,18 +44,19 @@ const adminConfig = {
   provider: 'openai',
   parameters: {
     model: 'gpt-4o-mini',
-    max_output_tokens: 500,
+    max_output_tokens: 200,
     temperature: 0.7,
     top_p: 1,
     stop_sequences: []
   },
-  prompt: 'Você é uma secretária jurídica especialista. Conduza a triagem em blocos e responda em português.',
+    prompt: 'Você é um advogado virtual. Converse em poucas palavras e em português. Pergunte qual é o problema do cliente e quais documentos possui. Se o tema for usucapião, questione se prefere via extrajudicial ou judicial e se deseja saber os custos de ambas, pesquisando nas tabelas de custas do TJMG. Quando tiver informações suficientes, encerre cordialmente e produza um relatório. Responda sempre em JSON como {"reply":"texto","done":bool,"report":"resumo"} e só inclua report quando done for true.',
   limits: { maxMessages: 20, maxChars: 1000 },
   features: { upload: false, ocr: false },
   apiKeys: {
     openai: process.env.OPENAI_API_KEY || '',
     anthropic: process.env.ANTHROPIC_API_KEY || '',
-    groq: process.env.GROQ_API_KEY || ''
+    groq: process.env.GROQ_API_KEY || '',
+    gemini: process.env.GEMINI_API_KEY || ''
   }
 };
 
@@ -89,21 +90,30 @@ app.post('/api/chat', chatLimiter, async (req, res) => {
   session.count++;
   session.messages.push({ role: 'user', content: message });
   sessions[sessionId] = session;
+  const apiKey = adminConfig.apiKeys[adminConfig.provider];
+  if (!apiKey) {
+    return res.status(400).json({ error: 'missing_api_key' });
+  }
   try {
-    const aiMessages = [{ role: 'system', content: adminConfig.prompt }, ...session.messages];
-    const reply = await generate(adminConfig.provider, adminConfig.apiKeys[adminConfig.provider], aiMessages, adminConfig.parameters);
-    session.messages.push({ role: 'assistant', content: reply });
-    res.json({ reply });
+  const aiMessages = [{ role: 'system', content: adminConfig.prompt }, ...session.messages];
+  const raw = await generate(adminConfig.provider, apiKey, aiMessages, adminConfig.parameters);
+  session.messages.push({ role: 'assistant', content: raw });
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    payload = { reply: raw };
+  }
+  if (payload.report) session.report = payload.report;
+  res.json(payload);
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: 'provider_error' });
+    res.status(500).json({ error: 'provider_error', message: e.message });
   }
 });
 
-const adminKey = process.env.ADMIN_KEY || 'secret';
-
 const configSchema = z.object({
-  provider: z.enum(['openai', 'anthropic', 'groq']).optional(),
+  provider: z.enum(['openai', 'anthropic', 'groq', 'gemini']).optional(),
   parameters: z.object({
     model: z.string().optional(),
     max_output_tokens: z.number().optional(),
@@ -119,12 +129,8 @@ const configSchema = z.object({
 const keySchema = z.object({
   openai: z.string().optional(),
   anthropic: z.string().optional(),
-  groq: z.string().optional()
-});
-
-app.use('/admin', (req, res, next) => {
-  if (req.headers['x-admin-key'] !== adminKey) return res.sendStatus(401);
-  next();
+  groq: z.string().optional(),
+  gemini: z.string().optional()
 });
 
 app.get('/admin/config', (req, res) => {


### PR DESCRIPTION
## Summary
- drop admin password requirement and parse AI JSON replies for report generation
- enhance lawyer dashboard with radio-style provider selection and report panel
- expand default prompt to ask about documents, usucapião options and cost lookup

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9b82352ec832dacbe4e4b589bd3ae