### PR TITLE
feat: streamline intake chat with auto-save prompt

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -70,10 +70,59 @@ async function groqGenerate(apiKey, messages, params) {
   return '';
 }
 
+async function detectGeminiModel(apiKey) {
+  try {
+    const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`);
+    const data = await res.json();
+    if (Array.isArray(data.models)) {
+      const flash = data.models
+        .map(m => m.name.replace('models/', ''))
+        .filter(name => /gemini-.*flash/i.test(name))
+        .sort((a, b) => {
+          const pa = parseFloat(a.match(/gemini-(\d+(?:\.\d+)?)/i)?.[1] || '0');
+          const pb = parseFloat(b.match(/gemini-(\d+(?:\.\d+)?)/i)?.[1] || '0');
+          return pb - pa;
+        })[0];
+      if (flash) return flash;
+    }
+  } catch (e) {
+    // silent
+  }
+  return 'gemini-2.0-flash';
+}
+
+async function geminiGenerate(apiKey, messages, params) {
+  const model = params.model || await detectGeminiModel(apiKey);
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: messages.map(m => ({
+        role: m.role === 'assistant' ? 'model' : 'user',
+        parts: [{ text: m.content }]
+      })),
+      generationConfig: {
+        maxOutputTokens: params.max_output_tokens,
+        temperature: params.temperature,
+        topP: params.top_p,
+        stopSequences: params.stop_sequences
+      }
+    })
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error && data.error.message ? data.error.message : 'gemini_error');
+  }
+  return data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text || '';
+}
+
 async function generate(provider, apiKey, messages, params) {
   switch (provider) {
     case 'anthropic':
       return anthropicGenerate(apiKey, messages, params);
+    case 'gemini':
+      return geminiGenerate(apiKey, messages, params);
     case 'groq':
       return groqGenerate(apiKey, messages, params);
     case 'openai':

--- a/public/admin.html
+++ b/public/admin.html
@@ -12,8 +12,10 @@
         <option value="openai">OpenAI</option>
         <option value="anthropic">Anthropic</option>
         <option value="groq">Groq</option>
+        <option value="gemini">Gemini</option>
       </select>
     </label>
+    <label>Modelo <input type="text" name="model" /></label>
     <label>Max tokens <input type="number" name="max_output_tokens" /></label>
     <label>Temperature <input type="number" step="0.1" name="temperature" /></label>
     <label>Top P <input type="number" step="0.1" name="top_p" /></label>
@@ -25,6 +27,7 @@
     <label>OpenAI <input type="password" name="openai" /></label>
     <label>Anthropic <input type="password" name="anthropic" /></label>
     <label>Groq <input type="password" name="groq" /></label>
+    <label>Gemini <input type="password" name="gemini" /></label>
     <button type="submit">Salvar chaves</button>
   </form>
   <script src="/admin.js"></script>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,8 +1,7 @@
 async function post(path, data) {
-  const key = prompt('Chave admin?');
   await fetch(path, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'x-admin-key': key },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
   });
 }
@@ -10,13 +9,16 @@ async function post(path, data) {
 document.getElementById('configForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const fd = new FormData(e.target);
+  const params = {
+    max_output_tokens: Number(fd.get('max_output_tokens')),
+    temperature: Number(fd.get('temperature')),
+    top_p: Number(fd.get('top_p'))
+  };
+  const model = fd.get('model').trim();
+  if (model) params.model = model;
   const data = {
     provider: fd.get('provider'),
-    parameters: {
-      max_output_tokens: Number(fd.get('max_output_tokens')),
-      temperature: Number(fd.get('temperature')),
-      top_p: Number(fd.get('top_p'))
-    },
+    parameters: params,
     prompt: fd.get('prompt')
   };
   await post('/admin/config', data);
@@ -29,7 +31,8 @@ document.getElementById('keyForm').addEventListener('submit', async (e) => {
   const data = {
     openai: fd.get('openai'),
     anthropic: fd.get('anthropic'),
-    groq: fd.get('groq')
+    groq: fd.get('groq'),
+    gemini: fd.get('gemini')
   };
   await post('/admin/keys', data);
   alert('Chaves salvas');

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -42,10 +42,59 @@
     <div class="panel" style="margin-top:14px;" id="chatPanel">
       <h3 style="margin-top:0;">Chat de Texto</h3>
       <div id="messages" class="chat-messages"></div>
+      <div id="quickReplies" class="actions quick-replies">
+        <button class="secondary quick-reply" data-msg="Olá, como posso ajudar?">Saudação</button>
+        <button class="secondary quick-reply" data-msg="Poderia fornecer mais detalhes?">Mais detalhes</button>
+        <button class="secondary quick-reply" data-msg="Vamos agendar uma reunião para discutir melhor?">Agendar reunião</button>
+        <button class="secondary quick-reply" data-msg="Estou analisando seu caso e retornarei em breve.">Analisar</button>
+      </div>
       <div class="chat-input">
         <input id="chatInput" type="text" placeholder="Digite sua mensagem" />
         <button id="sendBtn" class="primary" disabled>Enviar</button>
       </div>
+    </div>
+    <div class="panel" style="margin-top:14px;">
+      <h3 style="margin-top:0;">Configurações de IA</h3>
+      <form id="configForm" class="form-grid">
+        <div class="provider-field">
+          <span>Provedor</span>
+          <div class="provider-options">
+            <label class="provider-option"><input type="radio" name="provider" value="openai" checked/> OpenAI</label>
+            <label class="provider-option"><input type="radio" name="provider" value="anthropic"/> Anthropic</label>
+            <label class="provider-option"><input type="radio" name="provider" value="groq"/> Groq</label>
+            <label class="provider-option"><input type="radio" name="provider" value="gemini"/> Gemini</label>
+          </div>
+        </div>
+        <label>Modelo <input type="text" name="model" /></label>
+        <label>Max tokens <input type="number" name="max_output_tokens" value="200" /></label>
+        <label>Temperature <input type="number" step="0.1" name="temperature" value="0.7" /></label>
+        <label>Top P <input type="number" step="0.1" name="top_p" value="1" /></label>
+          <label>Prompt<br/>
+            <textarea name="prompt" rows="3">Você é um advogado virtual do escritório. Responda em português formal e breve. Ao receber o resumo do cliente, gere perguntas objetivas para coletar dados e verificar documentos, incluindo opções como usucapião judicial ou extrajudicial e seus custos no TJMG quando pertinente. Após as respostas do cliente, dê uma orientação final e finalize com uma linha "RELATORIO:" resumindo as informações para o advogado.</textarea>
+          </label>
+        <button type="submit" class="primary">Salvar Config</button>
+      </form>
+        <form id="keyForm" class="form-grid" style="margin-top:12px;">
+          <h4 style="margin:0;">API Key</h4>
+          <label class="key-field" data-provider="openai">OpenAI <input type="password" name="openai" /></label>
+          <label class="key-field" data-provider="anthropic">Anthropic <input type="password" name="anthropic" /></label>
+          <label class="key-field" data-provider="groq">Groq <input type="password" name="groq" /></label>
+          <label class="key-field" data-provider="gemini">Gemini <input type="password" name="gemini" /></label>
+          <button type="submit" class="secondary">Salvar Chave</button>
+        </form>
+    </div>
+    <div class="panel" style="margin-top:14px;" id="aiPanel">
+      <h3 style="margin-top:0;">Assistente de IA</h3>
+      <div id="aiMessages" class="chat-messages"></div>
+      <div class="chat-input">
+        <input id="aiInput" type="text" placeholder="Pergunte à IA" />
+        <button id="aiSendBtn" class="secondary">Enviar</button>
+      </div>
+    </div>
+    <div class="panel" style="margin-top:14px;" id="reportsPanel">
+      <h3 style="margin-top:0;">Relatórios</h3>
+      <button id="refreshReports" class="secondary">Atualizar</button>
+      <ul id="reportsList" class="reports-list"></ul>
     </div>
   </div>
 

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -11,6 +11,11 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   const messages = document.getElementById('messages');
   const chatInput = document.getElementById('chatInput');
   const sendBtn = document.getElementById('sendBtn');
+  const aiMessages = document.getElementById('aiMessages');
+  const aiInput = document.getElementById('aiInput');
+  const aiSendBtn = document.getElementById('aiSendBtn');
+  const reportsList = document.getElementById('reportsList');
+  const refreshReports = document.getElementById('refreshReports');
 
   const socket = io();
   socket.emit('identify', { role: 'lawyer' });
@@ -20,6 +25,125 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   let currentClientId = null;
   let pendingMode = 'video';
   let currentChatClientId = null;
+
+    const configForm = document.getElementById('configForm');
+    const keyForm = document.getElementById('keyForm');
+    const defaultModels = {
+      openai: 'gpt-4o-mini',
+      anthropic: 'claude-3-haiku-20240307',
+      groq: 'mixtral-8x7b-32768',
+      gemini: 'gemini-2.0-flash'
+    };
+
+    async function postAdmin(path, data) {
+    await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+    let saveTimer;
+
+    async function saveConfig() {
+      if (!configForm) return;
+      const fd = new FormData(configForm);
+      const params = {
+        max_output_tokens: Number(fd.get('max_output_tokens')),
+        temperature: Number(fd.get('temperature')),
+        top_p: Number(fd.get('top_p'))
+      };
+      const model = fd.get('model').trim();
+      if (model) params.model = model;
+      const data = {
+        provider: fd.get('provider'),
+        parameters: params,
+        prompt: fd.get('prompt')
+      };
+      await postAdmin('/admin/config', data);
+    }
+
+    async function loadConfig() {
+      try {
+        const res = await fetch('/admin/config');
+        const data = await res.json();
+        if (configForm) {
+          const prov = configForm.querySelector(`input[name="provider"][value="${data.provider}"]`);
+          if (prov) prov.checked = true;
+          configForm.querySelector('input[name="max_output_tokens"]').value = data.parameters.max_output_tokens;
+          configForm.querySelector('input[name="temperature"]').value = data.parameters.temperature;
+          configForm.querySelector('input[name="top_p"]').value = data.parameters.top_p;
+          configForm.querySelector('textarea[name="prompt"]').value = data.prompt;
+          const modelInput = configForm.querySelector('input[name="model"]');
+          if (modelInput) modelInput.value = data.parameters.model || defaultModels[data.provider];
+        }
+      } catch (e) {
+        console.error('config load error', e);
+      }
+    }
+
+    async function loadKeys() {
+      try {
+        const res = await fetch('/admin/keys');
+        const data = await res.json();
+        if (keyForm) {
+          ['openai','anthropic','groq','gemini'].forEach(k => {
+            const inp = keyForm.querySelector(`input[name="${k}"]`);
+            if (inp) inp.value = data[k] || '';
+          });
+        }
+      } catch (e) {
+        console.error('key load error', e);
+      }
+    }
+
+    function updateProviderSettings({ skipModel } = {}) {
+      if (!configForm || !keyForm) return;
+      const selected = configForm.querySelector('input[name="provider"]:checked').value;
+      keyForm.querySelectorAll('label.key-field').forEach(l => {
+        l.style.display = l.dataset.provider === selected ? 'block' : 'none';
+      });
+      if (!skipModel) {
+        const modelInput = configForm.querySelector('input[name="model"]');
+        if (modelInput) modelInput.value = defaultModels[selected];
+      }
+    }
+
+    loadConfig().then(() => {
+      updateProviderSettings({ skipModel: true });
+      saveConfig();
+    });
+    loadKeys();
+
+    if (configForm) {
+      configForm.addEventListener('change', (e) => {
+        if (e.target.name === 'provider') updateProviderSettings();
+        clearTimeout(saveTimer); saveTimer = setTimeout(saveConfig, 300);
+      });
+      configForm.addEventListener('input', () => {
+        clearTimeout(saveTimer); saveTimer = setTimeout(saveConfig, 300);
+      });
+      configForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        await saveConfig();
+        alert('Configuração salva');
+      });
+    }
+
+    if (keyForm) {
+      keyForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const fd = new FormData(keyForm);
+        const data = {
+          openai: fd.get('openai'),
+        anthropic: fd.get('anthropic'),
+        groq: fd.get('groq'),
+        gemini: fd.get('gemini')
+      };
+        await postAdmin('/admin/keys', data);
+        alert('Chaves salvas');
+      });
+    }
 
   function setInfo(text) { info.textContent = text; }
 
@@ -65,17 +189,18 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   });
 
   // Chat
-  function appendMessage(sender, text) {
+  function appendMessage(container, role, text) {
     const div = document.createElement('div');
-    div.textContent = `${sender}: ${text}`;
-    messages.appendChild(div);
-    messages.scrollTop = messages.scrollHeight;
+    div.className = `msg ${role}`;
+    div.textContent = text;
+    container.appendChild(div);
+    container.scrollTop = container.scrollHeight;
   }
 
   function sendChat() {
     const msg = chatInput.value.trim();
     if (!msg || !currentChatClientId) return;
-    appendMessage('Você', msg);
+    appendMessage(messages, 'you', `Você: ${msg}`);
     socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
     chatInput.value = '';
   }
@@ -85,10 +210,35 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
     if (e.key === 'Enter') { e.preventDefault(); sendChat(); }
   });
 
+  async function askAi(sessionId, msg) {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, message: msg })
+    });
+    return res.json();
+  }
+
   socket.on('chat-message', ({ from, message }) => {
     currentChatClientId = from;
-    appendMessage('Cliente', message);
+    appendMessage(messages, 'client', `Cliente: ${message}`);
     sendBtn.disabled = false;
+    askAi(from, message).then(data => {
+      if (data.reply) {
+        appendMessage(aiMessages, 'ai', `Sugestão: ${data.reply}`);
+      } else if (data.error) {
+        const map = {
+          missing_api_key: 'Chave de API ausente.',
+          limit_reached: 'Limite de uso atingido.',
+          msg_too_long: 'Mensagem muito longa.',
+          session_closed: 'Sessão encerrada.'
+        };
+        appendMessage(aiMessages, 'error', `Erro IA: ${map[data.error] || data.message || data.error}`);
+      }
+    }).catch(e => {
+      console.error('AI error', e);
+      appendMessage(aiMessages, 'error', 'Erro IA inesperado.');
+    });
   });
 
   socket.on('webrtc-offer', async ({ from, sdp }) => {
@@ -172,5 +322,65 @@ import { getMediaWithFallback, explainGetUserMediaError, isPotentiallyInsecureCo
   // Aviso de contexto inseguro
   if (isPotentiallyInsecureContext()) {
     setInfo('Aviso: contexto inseguro pode bloquear câmera/microfone. Use localhost ou HTTPS.');
+  }
+
+  document.querySelectorAll('.quick-reply').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const msg = btn.dataset.msg;
+      if (!msg || !currentChatClientId) return;
+      appendMessage(messages, 'you', `Você: ${msg}`);
+      socket.emit('chat-message', { targetId: currentChatClientId, message: msg });
+    });
+  });
+
+  function sendAi() {
+    const msg = aiInput.value.trim();
+    if (!msg) return;
+    appendMessage(aiMessages, 'you', `Você: ${msg}`);
+    aiInput.value = '';
+    askAi('lawyer-assistant', msg).then(data => {
+      if (data.reply) {
+        appendMessage(aiMessages, 'ai', `IA: ${data.reply}`);
+      } else if (data.error) {
+        const map = {
+          missing_api_key: 'Chave de API ausente.',
+          limit_reached: 'Limite de uso atingido.',
+          msg_too_long: 'Mensagem muito longa.',
+          session_closed: 'Sessão encerrada.'
+        };
+        appendMessage(aiMessages, 'error', `Erro IA: ${map[data.error] || data.message || data.error}`);
+      }
+    }).catch(e => {
+      console.error('AI error', e);
+      appendMessage(aiMessages, 'error', 'Erro IA inesperado.');
+    });
+  }
+
+  if (aiSendBtn) {
+    aiSendBtn.addEventListener('click', sendAi);
+    aiInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') { e.preventDefault(); sendAi(); } });
+  }
+
+  async function loadReports() {
+    try {
+      const res = await fetch('/admin/reports');
+      const list = await res.json();
+      if (!reportsList) return;
+      reportsList.innerHTML = '';
+      list.forEach(r => {
+        const li = document.createElement('li');
+        const date = new Date(r.timestamp).toLocaleString();
+        const contact = r.name ? ` - ${r.name} (${r.contact || ''})` : '';
+        li.textContent = `${date}${contact}: ${r.text}`;
+        reportsList.appendChild(li);
+      });
+    } catch (e) {
+      console.error('report load error', e);
+    }
+  }
+
+  if (refreshReports) {
+    refreshReports.addEventListener('click', loadReports);
+    loadReports();
   }
 })();

--- a/public/secretary.js
+++ b/public/secretary.js
@@ -11,27 +11,151 @@ function append(role, text) {
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
 
-async function send() {
-  const message = inputEl.value.trim();
-  if (!message) return;
-  append('user', message);
+let stage = 'summary';
+let currentQuestions = [];
+
+append('assistant', 'Olá! Sou a assistente jurídica. Escreva um breve resumo da sua demanda.');
+
+async function handleSummary() {
+  const summary = inputEl.value.trim();
+  if (!summary) return;
+  append('user', summary);
   inputEl.value = '';
+  sendBtn.disabled = true;
+  append('assistant', 'Analisando...');
   try {
-    const res = await fetch('/api/chat', {
+    const res = await fetch('/api/questions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sessionId, message })
+      body: JSON.stringify({ sessionId, summary })
     });
     const data = await res.json();
-    append('assistant', data.reply || '[erro]');
+    const map = {
+      missing_api_key: 'Chave de API ausente.',
+      limit_reached: 'Limite de uso atingido.',
+      msg_too_long: 'Resumo muito longo.',
+      invalid_request: 'Pedido inválido.'
+    };
+    if (!res.ok) {
+      const msg = map[data.error] || data.message || data.error;
+      append('error', msg === 'invalid_json' ? 'Resposta inválida da IA.' : msg);
+      sendBtn.disabled = false;
+      return;
+    }
+    currentQuestions = Array.isArray(data.questions) ? data.questions : [];
+    if (!currentQuestions.length) {
+      append('error', 'Nenhuma pergunta gerada.');
+      sendBtn.disabled = false;
+      return;
+    }
+    renderQuestions();
   } catch (e) {
-    append('assistant', '[erro de rede]');
+    append('error', 'Erro de rede.');
+    sendBtn.disabled = false;
   }
 }
 
-sendBtn.addEventListener('click', send);
-inputEl.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter') send();
+function renderQuestions() {
+  const inputWrap = inputEl.parentElement;
+  if (inputWrap) inputWrap.style.display = 'none';
+  const form = document.createElement('form');
+  form.id = 'questionsForm';
+  currentQuestions.forEach(q => {
+    const label = document.createElement('label');
+    label.textContent = q.pergunta;
+    let inp;
+    if (q.tipo === 'textarea') {
+      inp = document.createElement('textarea');
+    } else {
+      inp = document.createElement('input');
+      inp.type = q.tipo === 'number' ? 'number' : 'text';
+    }
+    inp.name = q.id;
+    label.appendChild(inp);
+    form.appendChild(label);
+  });
+  const btn = document.createElement('button');
+  btn.textContent = 'Enviar respostas';
+  btn.className = 'primary';
+  form.appendChild(btn);
+  messagesEl.appendChild(form);
+  stage = 'questions';
+  form.addEventListener('submit', submitAnswers);
+}
+
+async function submitAnswers(e) {
+  e.preventDefault();
+  const fd = new FormData(e.target);
+  const answers = {};
+  fd.forEach((v, k) => answers[k] = v);
+  e.target.remove();
+  currentQuestions.forEach(q => {
+    append('assistant', q.pergunta);
+    append('user', answers[q.id] || '');
+  });
+  append('assistant', 'Gerando orientação...');
+  try {
+    const res = await fetch('/api/answers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, answers })
+    });
+    const data = await res.json();
+    const map = {
+      missing_api_key: 'Chave de API ausente.',
+      limit_reached: 'Limite de uso atingido.',
+      invalid_session: 'Sessão inválida.',
+      msg_too_long: 'Mensagem muito longa.'
+    };
+    if (!res.ok) {
+      const msg = map[data.error] || data.message || data.error;
+      append('error', msg === 'invalid_json' ? 'Resposta inválida da IA.' : msg);
+      return;
+    }
+    append('assistant', data.reply || '[erro]');
+    renderContact();
+    stage = 'done';
+  } catch (e) {
+    append('error', 'Erro de rede.');
+  }
+}
+
+function renderContact() {
+  const form = document.createElement('form');
+  form.id = 'contactForm';
+  const name = document.createElement('input');
+  name.placeholder = 'Seu nome';
+  name.name = 'name';
+  const cont = document.createElement('input');
+  cont.placeholder = 'Email ou telefone';
+  cont.name = 'contact';
+  const btn = document.createElement('button');
+  btn.textContent = 'Enviar contato';
+  btn.className = 'secondary';
+  form.append(name, cont, btn);
+  messagesEl.appendChild(form);
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData(form);
+    try {
+      await fetch('/api/report-contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, name: fd.get('name'), contact: fd.get('contact') })
+      });
+    } catch {}
+    form.remove();
+    append('assistant', 'Obrigado! Em breve entraremos em contato.');
+  });
+}
+
+sendBtn.addEventListener('click', () => {
+  if (stage === 'summary') handleSummary();
 });
 
-append('assistant', 'Olá! Sou a secretária virtual. Como posso ajudar?');
+inputEl.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    if (stage === 'summary') handleSummary();
+  }
+});

--- a/public/style.css
+++ b/public/style.css
@@ -135,6 +135,65 @@ h2::after {
   flex-wrap: wrap;
 }
 
+.quick-replies {
+  margin-bottom: 8px;
+}
+.quick-replies button {
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  margin-top: 4px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #0b1224;
+  color: var(--text);
+}
+
+.provider-options {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.provider-option {
+  background: #1f2937;
+  padding: 4px 8px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.provider-option input { margin: 0; }
+
+.provider-field { display: flex; flex-direction: column; gap: 4px; }
+.provider-field span { font-size: 14px; }
+
+.reports-list {
+  list-style: disc;
+  padding-left: 20px;
+  max-height: 200px;
+  overflow-y: auto;
+  margin-top: 8px;
+}
+
+.reports-list li { margin-bottom: 6px; }
+
 button.primary {
     background: linear-gradient(90deg, #22c55e, #16a34a);
     color: #052e16;
@@ -262,6 +321,21 @@ button.danger { background: #ef4444; color: white; }
   white-space: pre-wrap;
 }
 
+.chat-messages .msg.you {
+  background: #1e293b;
+  text-align: right;
+}
+
+.chat-messages .msg.client {
+  background: #334155;
+}
+
+.chat-messages .msg.ai {
+  background: #1e293b;
+  border-left: 2px solid var(--accent);
+  font-style: italic;
+}
+
 .chat-messages .msg.user {
   background: #1e293b;
   text-align: right;
@@ -269,6 +343,41 @@ button.danger { background: #ef4444; color: white; }
 
 .chat-messages .msg.assistant {
   background: #334155;
+  border-left: 2px solid var(--accent);
+}
+
+.chat-messages .msg.error {
+  background: #7f1d1d;
+  color: #fecaca;
+  text-align: center;
+}
+
+.chat-messages form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 8px 0;
+}
+
+.chat-messages form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+
+.chat-messages form input,
+.chat-messages form textarea {
+  margin-top: 4px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #0b1224;
+  color: var(--text);
+}
+
+.form-grid textarea[name="prompt"] {
+  font-family: monospace;
+  white-space: pre-wrap;
 }
 
 .chat-input {
@@ -286,6 +395,10 @@ button.danger { background: #ef4444; color: white; }
 }
 
 .chat-input button { flex-shrink: 0; }
+
+.key-field {
+  display: none;
+}
 
 @media (max-width: 900px) {
   .hero { grid-template-columns: 1fr; }

--- a/server.js
+++ b/server.js
@@ -9,6 +9,9 @@ const { z } = require('zod');
 const { generate } = require('./providers');
 
 const app = express();
+// Permitir que o Express confie nos cabeçalhos X-Forwarded-* quando estiver atrás de proxies
+// evitando erros do express-rate-limit quando esses cabeçalhos forem adicionados.
+app.set('trust proxy', 1);
 
 // Detectar certificados locais para HTTPS
 let server;
@@ -44,22 +47,25 @@ const adminConfig = {
   provider: 'openai',
   parameters: {
     model: 'gpt-4o-mini',
-    max_output_tokens: 500,
+    max_output_tokens: 200,
     temperature: 0.7,
     top_p: 1,
     stop_sequences: []
   },
-  prompt: 'Você é uma secretária jurídica especialista. Conduza a triagem em blocos e responda em português.',
+  prompt: 'Você é um advogado virtual do escritório. Responda em português formal e de maneira breve. Ao receber o resumo do cliente, gere perguntas objetivas para coletar dados e verificar documentos, incluindo opções como usucapião judicial ou extrajudicial com seus respectivos custos no TJMG quando cabível. Depois das respostas do cliente, forneça uma orientação final e encerre com uma linha "RELATORIO:" resumindo as informações para o advogado.',
   limits: { maxMessages: 20, maxChars: 1000 },
   features: { upload: false, ocr: false },
   apiKeys: {
     openai: process.env.OPENAI_API_KEY || '',
     anthropic: process.env.ANTHROPIC_API_KEY || '',
-    groq: process.env.GROQ_API_KEY || ''
+    groq: process.env.GROQ_API_KEY || '',
+    gemini: process.env.GEMINI_API_KEY || ''
   }
 };
 
 const sessions = {};
+const reports = [];
+const intakes = {};
 
 // Endpoint simples para formulário de contato
 app.post('/contact', (req, res) => {
@@ -73,6 +79,22 @@ const messageSchema = z.object({
   message: z.string().min(1)
 });
 
+const summarySchema = z.object({
+  sessionId: z.string(),
+  summary: z.string().min(1)
+});
+
+const answersSchema = z.object({
+  sessionId: z.string(),
+  answers: z.record(z.string())
+});
+
+const contactSchema = z.object({
+  sessionId: z.string(),
+  name: z.string(),
+  contact: z.string()
+});
+
 app.post('/api/chat', chatLimiter, async (req, res) => {
   const parsed = messageSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -82,28 +104,127 @@ app.post('/api/chat', chatLimiter, async (req, res) => {
   if (message.length > adminConfig.limits.maxChars) {
     return res.status(400).json({ error: 'msg_too_long' });
   }
-  const session = sessions[sessionId] || { count: 0, messages: [] };
+  const session = sessions[sessionId] || { count: 0, messages: [], done: false };
+  if (session.done) {
+    return res.status(400).json({ error: 'session_closed' });
+  }
   if (session.count >= adminConfig.limits.maxMessages) {
     return res.status(400).json({ error: 'limit_reached' });
   }
   session.count++;
   session.messages.push({ role: 'user', content: message });
   sessions[sessionId] = session;
+  const apiKey = adminConfig.apiKeys[adminConfig.provider];
+  if (!apiKey) {
+    return res.status(400).json({ error: 'missing_api_key' });
+  }
   try {
     const aiMessages = [{ role: 'system', content: adminConfig.prompt }, ...session.messages];
-    const reply = await generate(adminConfig.provider, adminConfig.apiKeys[adminConfig.provider], aiMessages, adminConfig.parameters);
+    const reply = await generate(adminConfig.provider, apiKey, aiMessages, adminConfig.parameters);
     session.messages.push({ role: 'assistant', content: reply });
-    res.json({ reply });
+    let clientReply = reply;
+    const idx = reply.indexOf('RELATORIO:');
+    if (idx !== -1) {
+      clientReply = reply.slice(0, idx).trim();
+      const reportText = reply.slice(idx + 'RELATORIO:'.length).trim();
+      reports.push({ sessionId, text: reportText, timestamp: Date.now() });
+      session.done = true;
+    }
+    res.json({ reply: clientReply });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: 'provider_error' });
+    res.status(500).json({ error: 'provider_error', message: e.message });
   }
 });
 
-const adminKey = process.env.ADMIN_KEY || 'secret';
+app.post('/api/questions', chatLimiter, async (req, res) => {
+  const parsed = summarySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'invalid_request' });
+  }
+  const { sessionId, summary } = parsed.data;
+  if (summary.length > adminConfig.limits.maxChars) {
+    return res.status(400).json({ error: 'msg_too_long' });
+  }
+  const apiKey = adminConfig.apiKeys[adminConfig.provider];
+  if (!apiKey) {
+    return res.status(400).json({ error: 'missing_api_key' });
+  }
+  try {
+    const sys = `${adminConfig.prompt}\nResponda apenas com JSON.`;
+    const messages = [
+      { role: 'system', content: sys },
+      { role: 'user', content: `Resumo: ${summary}\nListe as principais perguntas necessárias para orientar o caso.` }
+    ];
+    const reply = await generate(adminConfig.provider, apiKey, messages, adminConfig.parameters);
+    // Alguns provedores podem envolver a saída em blocos de código. Removemos
+    // quaisquer cercas ``` antes de tentar interpretar o JSON.
+    const cleaned = reply.replace(/```(json)?|```/gi, '').trim();
+    let questions;
+    try {
+      questions = JSON.parse(cleaned);
+    } catch {
+      throw new Error('invalid_json');
+    }
+    intakes[sessionId] = { summary, questions, stage: 'questions' };
+    res.json({ questions });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'provider_error', message: e.message });
+  }
+});
+
+app.post('/api/answers', chatLimiter, async (req, res) => {
+  const parsed = answersSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'invalid_request' });
+  }
+  const { sessionId, answers } = parsed.data;
+  const intake = intakes[sessionId];
+  if (!intake || intake.stage !== 'questions') {
+    return res.status(400).json({ error: 'invalid_session' });
+  }
+  const apiKey = adminConfig.apiKeys[adminConfig.provider];
+  if (!apiKey) {
+    return res.status(400).json({ error: 'missing_api_key' });
+  }
+  try {
+    const answersText = Object.entries(answers).map(([k, v]) => `${k}: ${v}`).join('\n');
+    const userText = `Resumo: ${intake.summary}\nRespostas:\n${answersText}\nForneça orientação final e finalize com RELATORIO:`;
+    const messages = [
+      { role: 'system', content: adminConfig.prompt },
+      { role: 'user', content: userText }
+    ];
+    const reply = await generate(adminConfig.provider, apiKey, messages, adminConfig.parameters);
+    let clientReply = reply;
+    const idx = reply.indexOf('RELATORIO:');
+    if (idx !== -1) {
+      clientReply = reply.slice(0, idx).trim();
+      const reportText = reply.slice(idx + 'RELATORIO:'.length).trim();
+      reports.push({ sessionId, text: reportText, timestamp: Date.now() });
+      intake.stage = 'done';
+    }
+    res.json({ reply: clientReply });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'provider_error', message: e.message });
+  }
+});
+
+app.post('/api/report-contact', (req, res) => {
+  const parsed = contactSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'invalid_request' });
+  const { sessionId, name, contact } = parsed.data;
+  const rpt = reports.find(r => r.sessionId === sessionId);
+  if (rpt) {
+    rpt.name = name;
+    rpt.contact = contact;
+  }
+  res.json({ ok: true });
+});
 
 const configSchema = z.object({
-  provider: z.enum(['openai', 'anthropic', 'groq']).optional(),
+  provider: z.enum(['openai', 'anthropic', 'groq', 'gemini']).optional(),
   parameters: z.object({
     model: z.string().optional(),
     max_output_tokens: z.number().optional(),
@@ -119,12 +240,8 @@ const configSchema = z.object({
 const keySchema = z.object({
   openai: z.string().optional(),
   anthropic: z.string().optional(),
-  groq: z.string().optional()
-});
-
-app.use('/admin', (req, res, next) => {
-  if (req.headers['x-admin-key'] !== adminKey) return res.sendStatus(401);
-  next();
+  groq: z.string().optional(),
+  gemini: z.string().optional()
 });
 
 app.get('/admin/config', (req, res) => {
@@ -145,6 +262,14 @@ app.post('/admin/keys', (req, res) => {
   if (!parsed.success) return res.status(400).json({ error: 'invalid_keys' });
   adminConfig.apiKeys = { ...adminConfig.apiKeys, ...parsed.data };
   res.json({ ok: true });
+});
+
+app.get('/admin/keys', (req, res) => {
+  res.json(adminConfig.apiKeys);
+});
+
+app.get('/admin/reports', (req, res) => {
+  res.json(reports);
 });
 
 let lawyerSocket = null; // socket do advogado


### PR DESCRIPTION
## Summary
- auto-save AI prompt and config so settings persist without manual save
- overhaul client intake chat: AI lists follow-up questions, gathers answers, and records contact info with final report
- improve chat and prompt formatting and show contact details in lawyer reports
- trust proxy headers and strip code fences from AI JSON responses to avoid 500 errors
- clarify secretary chat interaction with status messages and friendly error handling

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9b82352ec832dacbe4e4b589bd3ae