### PR TITLE
Improve responsive layout for home page

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -428,10 +428,16 @@ body { scroll-behavior: smooth; }
   z-index: 50;
 }
 
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .nav-links a {
   color: var(--text);
   text-decoration: none;
-  margin-left: 16px;
+  margin: 0;
   transition: color 0.3s;
   font-weight: 500;
 }
@@ -445,7 +451,10 @@ body { scroll-behavior: smooth; }
   animation: fadeIn 1s ease forwards;
 }
 
-.hero-section h1 { font-size: 42px; margin-bottom: 16px; }
+.hero-section h1 {
+  font-size: clamp(32px, calc(5vw + 16px), 56px);
+  margin-bottom: 16px;
+}
 .hero-section p { color: var(--muted); margin-bottom: 24px; }
 
 .about-section,
@@ -553,6 +562,29 @@ body { scroll-behavior: smooth; }
 
 .form-status.success { color: var(--accent); }
 .form-status.error { color: var(--accent-2); }
+
+@media (max-width: 600px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+  }
+  .nav-links {
+    width: 100%;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .nav-links a {
+    padding: 8px 0;
+  }
+  .hero-section {
+    padding: 60px 16px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .container { max-width: 1300px; }
+}
 
 .reveal {
   opacity: 0;


### PR DESCRIPTION
## Summary
- Refine navigation styling using flexbox and responsive spacing
- Make hero heading and section adapt across screen sizes
- Add mobile-first and wide-screen media queries

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa194f03c0832d898e9b31fa4f0edb