### PR TITLE
Improve home page responsive layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -32,7 +32,7 @@ body::before {
 }
 
 .container {
-    max-width: 1100px;
+    max-width: 1200px;
     margin: 0 auto;
     padding: 16px;
   }
@@ -563,6 +563,42 @@ body { scroll-behavior: smooth; }
 .reveal.visible {
   opacity: 1;
   transform: none;
+}
+
+@media (max-width: 600px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-links {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    margin-top: 8px;
+  }
+
+  .nav-links a {
+    margin: 4px 8px 0 0;
+  }
+
+  .hero-section {
+    padding: 80px 16px;
+  }
+
+  .hero-section h1 {
+    font-size: 32px;
+  }
+}
+
+@media (min-width: 1400px) {
+  .hero-section {
+    padding: 160px 16px;
+  }
+
+  .hero-section h1 {
+    font-size: 56px;
+  }
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- expand content width to improve presentation on large screens
- add mobile-friendly header and hero adjustments
- scale hero layout for extra-wide displays

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa194f03c0832d898e9b31fa4f0edb