### PR TITLE
feat: enable markdown chat and multi questions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -175,8 +175,9 @@
 
   <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="/client.js"></script>
-  <script src="/background.js"></script>
-  <script src="/main.js"></script>
-  <script src="/secretary.js"></script>
+<script src="/background.js"></script>
+<script src="/main.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="/secretary.js"></script>
 </body>
 </html>

--- a/public/secretary.js
+++ b/public/secretary.js
@@ -6,7 +6,7 @@ const sessionId = crypto.randomUUID();
 function append(role, text) {
   const div = document.createElement('div');
   div.className = 'msg ' + role;
-  div.textContent = text;
+  div.innerHTML = window.marked ? marked.parse(text) : text;
   messagesEl.appendChild(div);
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
@@ -60,17 +60,34 @@ function renderQuestions() {
   if (inputWrap) inputWrap.style.display = 'none';
   const form = document.createElement('form');
   form.id = 'questionsForm';
-  currentQuestions.forEach(q => {
+  currentQuestions.forEach((q, idx) => {
     const label = document.createElement('label');
-    label.textContent = q.pergunta;
+    label.textContent = `${idx + 1}. ${q.pergunta}`;
     let inp;
     if (q.tipo === 'textarea') {
       inp = document.createElement('textarea');
     } else {
       inp = document.createElement('input');
-      inp.type = q.tipo === 'number' ? 'number' : 'text';
+      if (q.tipo === 'number') inp.type = 'number';
+      else if (q.tipo === 'date') inp.type = 'date';
+      else inp.type = 'text';
     }
     inp.name = q.id;
+    if (Array.isArray(q.opcoes) && q.opcoes.length) {
+      const optionsDiv = document.createElement('div');
+      optionsDiv.className = 'quick-replies';
+      q.opcoes.forEach(opt => {
+        const optBtn = document.createElement('button');
+        optBtn.type = 'button';
+        optBtn.textContent = opt;
+        optBtn.className = 'secondary';
+        optBtn.addEventListener('click', () => {
+          inp.value = opt;
+        });
+        optionsDiv.appendChild(optBtn);
+      });
+      label.appendChild(optionsDiv);
+    }
     label.appendChild(inp);
     form.appendChild(label);
   });
@@ -89,8 +106,8 @@ async function submitAnswers(e) {
   const answers = {};
   fd.forEach((v, k) => answers[k] = v);
   e.target.remove();
-  currentQuestions.forEach(q => {
-    append('assistant', q.pergunta);
+  currentQuestions.forEach((q, idx) => {
+    append('assistant', `${idx + 1}. ${q.pergunta}`);
     append('user', answers[q.id] || '');
   });
   append('assistant', 'Gerando orientação...');

--- a/server.js
+++ b/server.js
@@ -173,7 +173,7 @@ app.post('/api/questions', chatLimiter, async (req, res) => {
     return res.status(400).json({ error: 'missing_api_key' });
   }
   try {
-    const sys = 'Você gera perguntas em formato JSON. Responda somente com um array JSON de objetos {"id","pergunta","tipo"}. O campo tipo deve ser "text", "number" ou "textarea".';
+    const sys = 'Você gera perguntas em formato JSON. Responda somente com um array JSON de objetos {"id","pergunta","tipo","opcoes"}. O campo tipo deve ser "text", "number", "date" ou "textarea". Se houver alternativas pré-definidas, inclua "opcoes" como um array de strings curtas.';
     const messages = [
       { role: 'system', content: sys },
       { role: 'user', content: `Resumo: ${summary}. Liste as perguntas necessárias para orientar o caso.` }


### PR DESCRIPTION
## Summary
- allow the question generator to produce date fields and predefined options
- render secretary chat messages as Markdown and support quick-reply buttons
- load `marked` on the landing page for Markdown parsing

## Testing
- `node --check server.js`
- `node --check public/secretary.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad05261700832dac0be6f077725524