### PR TITLE
Improve content editor UX on lawyer panel

### DIFF
--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -113,36 +113,52 @@
     </div>
     <div class="panel" style="margin-top:14px;" id="contentEditor">
       <h3 style="margin-top:0;">Editor de Conteúdo da Página Principal</h3>
-      <form id="contentForm">
-        <fieldset>
-          <legend>Seção Hero</legend>
-          <label>Título: <input type="text" name="hero.title" /></label>
-          <label>Subtítulo: <input type="text" name="hero.subtitle" /></label>
-          <label>Texto do Botão: <input type="text" name="hero.button.text" /></label>
-          <label>Link do Botão: <input type="text" name="hero.button.link" /></label>
-        </fieldset>
+      <form id="contentForm" class="form-grid">
+        <details open>
+          <summary>Seção Hero</summary>
+          <label>Título
+            <input type="text" name="hero.title" placeholder="Título principal" />
+          </label>
+          <label>Subtítulo
+            <input type="text" name="hero.subtitle" placeholder="Subtítulo descritivo" />
+          </label>
+          <label>Texto do Botão
+            <input type="text" name="hero.button.text" placeholder="Texto do botão" />
+          </label>
+          <label>Link do Botão
+            <input type="text" name="hero.button.link" placeholder="URL de destino" />
+          </label>
+        </details>
 
-        <fieldset>
-          <legend>Seção Sobre</legend>
-          <label>Título: <input type="text" name="about.title" /></label>
-          <label>Texto: <textarea name="about.text" rows="5"></textarea></label>
-        </fieldset>
+        <details>
+          <summary>Seção Sobre</summary>
+          <label>Título
+            <input type="text" name="about.title" placeholder="Título da seção" />
+          </label>
+          <label>Texto
+            <textarea name="about.text" rows="5" placeholder="Descrição sobre o escritório"></textarea>
+          </label>
+        </details>
 
-        <fieldset>
-          <legend>Seção Áreas de Atuação</legend>
-          <label>Título: <input type="text" name="areas.title" /></label>
-          <div id="areas-items"></div>
+        <details>
+          <summary>Seção Áreas de Atuação</summary>
+          <label>Título
+            <input type="text" name="areas.title" placeholder="Título da seção" />
+          </label>
+          <div id="areas-items" class="form-grid"></div>
           <button type="button" id="addArea" class="secondary">Adicionar Área</button>
-        </fieldset>
+        </details>
 
-        <fieldset>
-          <legend>Rodapé</legend>
-          <label>Texto: <input type="text" name="footer.text" /></label>
-          <div id="social-links"></div>
+        <details>
+          <summary>Rodapé</summary>
+          <label>Texto
+            <input type="text" name="footer.text" placeholder="Texto do rodapé" />
+          </label>
+          <div id="social-links" class="form-grid"></div>
           <button type="button" id="addSocial" class="secondary">Adicionar Rede Social</button>
-        </fieldset>
+        </details>
 
-        <button type="submit" class="primary" style="margin-top: 20px;">Salvar Conteúdo</button>
+        <button type="submit" class="primary save-content">Salvar Conteúdo</button>
       </form>
     </div>
   </div>

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -481,12 +481,14 @@ function renderAreas(items = []) {
     areasItems.innerHTML = '';
     items.forEach((item, index) => {
         const div = document.createElement('div');
-        div.className = 'area-item';
+        div.className = 'area-item form-grid';
         div.innerHTML = `
-            <label>Título: <input type="text" value="${item.title}" data-index="${index}" name="area-title"></label>
+            <button type="button" class="remove-area" data-index="${index}">&times;</button>
+            <label>Nome da Área
+                <input type="text" value="${item.title}" data-index="${index}" name="area-title" placeholder="Ex.: Direito Civil">
+            </label>
             <input type="hidden" value="${item.icon}" data-index="${index}" name="area-icon">
             <button type="button" class="choose-icon secondary" data-index="${index}">Escolher Ícone</button>
-            <button type="button" class="remove-area secondary" data-index="${index}">Remover</button>
         `;
         areasItems.appendChild(div);
     });
@@ -497,12 +499,18 @@ function renderSocial(items = []) {
     socialLinks.innerHTML = '';
     items.forEach((item, index) => {
         const div = document.createElement('div');
-        div.className = 'social-item';
+        div.className = 'social-item form-grid';
         div.innerHTML = `
-            <label>Nome: <input type="text" value="${item.name}" data-index="${index}" name="social-name"></label>
-            <label>Link: <input type="text" value="${item.link}" data-index="${index}" name="social-link"></label>
-            <label>Ícone (SVG Path): <input type="text" value="${item.icon}" data-index="${index}" name="social-icon"></label>
-            <button type="button" class="remove-social secondary" data-index="${index}">Remover</button>
+            <button type="button" class="remove-social" data-index="${index}">&times;</button>
+            <label>Nome
+                <input type="text" value="${item.name}" data-index="${index}" name="social-name" placeholder="Ex.: LinkedIn">
+            </label>
+            <label>Link
+                <input type="text" value="${item.link}" data-index="${index}" name="social-link" placeholder="https://...">
+            </label>
+            <label>Ícone (SVG Path)
+                <input type="text" value="${item.icon}" data-index="${index}" name="social-icon" placeholder="Path do ícone">
+            </label>
         `;
         socialLinks.appendChild(div);
     });

--- a/public/style.css
+++ b/public/style.css
@@ -913,7 +913,7 @@ input.not-informed {
   backdrop-filter: blur(10px);
 }
 
-#contentForm fieldset {
+#contentEditor details {
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 12px;
   padding: 20px;
@@ -921,11 +921,32 @@ input.not-informed {
   background: rgba(0,0,0,0.1);
 }
 
-#contentForm legend {
+#contentEditor summary {
   font-weight: 600;
-  padding: 0 10px;
-  color: var(--accent);
-  font-size: 18px;
+  padding: 0 4px;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+#contentEditor summary::-webkit-details-marker {
+  display: none;
+}
+
+#contentEditor details[open] > summary {
+  margin-bottom: 12px;
+}
+
+#contentEditor summary::after {
+  content: '\25bc';
+  font-size: 12px;
+  transition: transform 0.2s;
+}
+
+#contentEditor details[open] > summary::after {
+  transform: rotate(180deg);
 }
 
 #contentForm .form-row {
@@ -993,6 +1014,10 @@ input.not-informed {
 #contentForm .remove-social:hover {
     transform: scale(1.1);
     filter: brightness(1.1);
+}
+
+#contentEditor .save-content {
+  width: 100%;
 }
 
 


### PR DESCRIPTION
## Summary
- Rework main page content editor with collapsible sections and clearer placeholders
- Add styling for details/summary accordions and full-width save button
- Render dynamic area and social items with improved layout and inline removal buttons

## Testing
- `node --check public/lawyer.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae58830b64832d97e3c128f45a9789