### PR TITLE
Editor completo de conteúdo da página principal

### DIFF
--- a/public/content.json
+++ b/public/content.json
@@ -1,4 +1,18 @@
 {
+  "site": {
+    "title": "Escritório de Advocacia Online"
+  },
+  "nav": {
+    "about": "Sobre",
+    "areas": "Áreas",
+    "contact": "Contato",
+    "lawyer": "Área do Advogado"
+  },
+  "sections": {
+    "secretary": { "title": "Secretária Virtual" },
+    "contact": { "title": "Contato" },
+    "form": { "title": "Envie uma mensagem" }
+  },
   "hero": {
     "title": "Defendendo seus direitos com excelência",
     "subtitle": "Atendimento jurídico moderno, humano e eficiente.",

--- a/public/index.html
+++ b/public/index.html
@@ -37,23 +37,23 @@
   <header class="site-header">
     <div class="container header">
       <div class="brand">
-        
+
         <div>
-          <div style="font-weight:700;">Escritório de Advocacia Online</div>
+          <div id="siteBrand" style="font-weight:700;">Escritório de Advocacia Online</div>
           <div class="badge" id="statusBadge">Carregando status...</div>
         </div>
       </div>
       <nav class="nav-links">
         <a href="#contato" id="contactLink" class="hidden">Contato</a>
-        <a href="#sobre">Sobre</a>
-        <a href="#areas">Áreas</a>
-        <a class="secondary" href="/lawyer.html" title="Área do Advogado">Área do Advogado</a>
+        <a href="#sobre" id="navAbout">Sobre</a>
+        <a href="#areas" id="navAreas">Áreas</a>
+        <a class="secondary" href="/lawyer.html" id="navLawyer" title="Área do Advogado">Área do Advogado</a>
       </nav>
     </div>
   </header>
   <section id="secretaria" class="secretary-section">
     <div class="container">
-      <h2>Secretária Virtual</h2>
+      <h2 id="secretaryTitle">Secretária Virtual</h2>
       <div id="aiChat" class="chat">
         <div id="aiMessages" class="chat-messages"></div>
         <div class="chat-input">
@@ -65,7 +65,7 @@
   </section>
   <section id="contato" class="contact-section hidden">
     <div class="container">
-      <h2>Contato</h2>
+      <h2 id="contactTitle">Contato</h2>
       <div id="callInterface" class="panel contact-panel hidden">
         <div class="mode-bar" role="group" aria-label="Modo de comunicação">
           <label><input type="radio" name="mode" value="video" checked>Vídeo + Áudio</label>
@@ -150,7 +150,7 @@
   <div class="section-divider" aria-hidden="true"></div>
   <section id="formulario" class="form-section reveal">
     <div class="container">
-      <h2>Envie uma mensagem</h2>
+      <h2 id="formTitle">Envie uma mensagem</h2>
       <form class="contact-form">
         <input type="text" name="nome" placeholder="Seu nome" required />
         <input type="email" name="email" placeholder="Seu e-mail" required />
@@ -184,7 +184,28 @@
       try {
         const res = await fetch('/api/content');
         const content = await res.json();
-        
+
+        // Site & Navegação
+        document.title = content.site.title;
+        const brand = document.getElementById('siteBrand');
+        if (brand) brand.textContent = content.site.title;
+        const navAbout = document.getElementById('navAbout');
+        if (navAbout) navAbout.textContent = content.nav.about;
+        const navAreas = document.getElementById('navAreas');
+        if (navAreas) navAreas.textContent = content.nav.areas;
+        const navContact = document.getElementById('contactLink');
+        if (navContact) navContact.textContent = content.nav.contact;
+        const navLawyer = document.getElementById('navLawyer');
+        if (navLawyer) navLawyer.textContent = content.nav.lawyer;
+
+        // Títulos das seções
+        const secTitle = document.getElementById('secretaryTitle');
+        if (secTitle) secTitle.textContent = content.sections.secretary.title;
+        const contactTitle = document.getElementById('contactTitle');
+        if (contactTitle) contactTitle.textContent = content.sections.contact.title;
+        const formTitle = document.getElementById('formTitle');
+        if (formTitle) formTitle.textContent = content.sections.form.title;
+
         // Hero
         document.querySelector('.hero-section h1').textContent = content.hero.title;
         document.querySelector('.hero-section p').textContent = content.hero.subtitle;

--- a/public/lawyer.html
+++ b/public/lawyer.html
@@ -113,34 +113,46 @@
     </div>
     <div class="panel" style="margin-top:14px;" id="contentEditor">
       <h3 style="margin-top:0;">Editor de Conteúdo da Página Principal</h3>
-      <form id="contentForm">
-        <fieldset>
-          <legend>Seção Hero</legend>
-          <label>Título: <input type="text" name="hero.title" /></label>
-          <label>Subtítulo: <input type="text" name="hero.subtitle" /></label>
-          <label>Texto do Botão: <input type="text" name="hero.button.text" /></label>
-          <label>Link do Botão: <input type="text" name="hero.button.link" /></label>
-        </fieldset>
+      <form id="contentForm" class="form-grid">
+        <details open>
+          <summary>Configurações do Site</summary>
+          <label>Nome do Site: <input type="text" name="site.title" placeholder="Ex.: Escritório de Advocacia" /></label>
+          <label>Menu Sobre: <input type="text" name="nav.about" placeholder="Ex.: Sobre" /></label>
+          <label>Menu Áreas: <input type="text" name="nav.areas" placeholder="Ex.: Áreas" /></label>
+          <label>Menu Contato: <input type="text" name="nav.contact" placeholder="Ex.: Contato" /></label>
+          <label>Menu Advogado: <input type="text" name="nav.lawyer" placeholder="Ex.: Área do Advogado" /></label>
+          <label>Título Secretária: <input type="text" name="sections.secretary.title" placeholder="Ex.: Secretária Virtual" /></label>
+          <label>Título Contato: <input type="text" name="sections.contact.title" placeholder="Ex.: Contato" /></label>
+          <label>Título Formulário: <input type="text" name="sections.form.title" placeholder="Ex.: Envie uma mensagem" /></label>
+        </details>
 
-        <fieldset>
-          <legend>Seção Sobre</legend>
-          <label>Título: <input type="text" name="about.title" /></label>
-          <label>Texto: <textarea name="about.text" rows="5"></textarea></label>
-        </fieldset>
+        <details>
+          <summary>Seção Hero</summary>
+          <label>Título: <input type="text" name="hero.title" placeholder="Ex.: Defendendo seus direitos" /></label>
+          <label>Subtítulo: <input type="text" name="hero.subtitle" placeholder="Ex.: Atendimento jurídico personalizado" /></label>
+          <label>Texto do Botão: <input type="text" name="hero.button.text" placeholder="Ex.: Fale Conosco" /></label>
+          <label>Link do Botão: <input type="text" name="hero.button.link" placeholder="Ex.: /contato" /></label>
+        </details>
 
-        <fieldset>
-          <legend>Seção Áreas de Atuação</legend>
-          <label>Título: <input type="text" name="areas.title" /></label>
+        <details>
+          <summary>Seção Sobre</summary>
+          <label>Título: <input type="text" name="about.title" placeholder="Ex.: Sobre o Escritório" /></label>
+          <label>Texto: <textarea name="about.text" rows="5" placeholder="Conte a história do escritório..."></textarea></label>
+        </details>
+
+        <details>
+          <summary>Seção Áreas de Atuação</summary>
+          <label>Título: <input type="text" name="areas.title" placeholder="Ex.: Áreas de Atuação" /></label>
           <div id="areas-items"></div>
           <button type="button" id="addArea" class="secondary">Adicionar Área</button>
-        </fieldset>
+        </details>
 
-        <fieldset>
-          <legend>Rodapé</legend>
-          <label>Texto: <input type="text" name="footer.text" /></label>
+        <details>
+          <summary>Rodapé</summary>
+          <label>Texto: <input type="text" name="footer.text" placeholder="Ex.: © 2024 - Todos os direitos reservados" /></label>
           <div id="social-links"></div>
           <button type="button" id="addSocial" class="secondary">Adicionar Rede Social</button>
-        </fieldset>
+        </details>
 
         <button type="submit" class="primary" style="margin-top: 20px;">Salvar Conteúdo</button>
       </form>

--- a/public/lawyer.js
+++ b/public/lawyer.js
@@ -463,6 +463,15 @@ async function loadContent() {
 
 function populateForm(content) {
     if (!contentForm) return;
+    contentForm.querySelector('[name="site.title"]').value = content.site?.title || '';
+    contentForm.querySelector('[name="nav.about"]').value = content.nav?.about || '';
+    contentForm.querySelector('[name="nav.areas"]').value = content.nav?.areas || '';
+    contentForm.querySelector('[name="nav.contact"]').value = content.nav?.contact || '';
+    contentForm.querySelector('[name="nav.lawyer"]').value = content.nav?.lawyer || '';
+    contentForm.querySelector('[name="sections.secretary.title"]').value = content.sections?.secretary?.title || '';
+    contentForm.querySelector('[name="sections.contact.title"]').value = content.sections?.contact?.title || '';
+    contentForm.querySelector('[name="sections.form.title"]').value = content.sections?.form?.title || '';
+
     contentForm.querySelector('[name="hero.title"]').value = content.hero.title;
     contentForm.querySelector('[name="hero.subtitle"]').value = content.hero.subtitle;
     contentForm.querySelector('[name="hero.button.text"]').value = content.hero.button.text;
@@ -482,11 +491,17 @@ function renderAreas(items = []) {
     items.forEach((item, index) => {
         const div = document.createElement('div');
         div.className = 'area-item';
+        const iconSvg = item.icon
+            ? `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="${item.icon}"/></svg>`
+            : '<span class="icon-placeholder">?</span>';
         div.innerHTML = `
-            <label>Título: <input type="text" value="${item.title}" data-index="${index}" name="area-title"></label>
+            <button type="button" class="remove-area" data-index="${index}">&times;</button>
+            <div class="area-main">
+                <span class="area-icon-preview" data-index="${index}">${iconSvg}</span>
+                <label>Título: <input type="text" value="${item.title}" data-index="${index}" name="area-title" placeholder="Ex.: Direito Civil"></label>
+            </div>
             <input type="hidden" value="${item.icon}" data-index="${index}" name="area-icon">
             <button type="button" class="choose-icon secondary" data-index="${index}">Escolher Ícone</button>
-            <button type="button" class="remove-area secondary" data-index="${index}">Remover</button>
         `;
         areasItems.appendChild(div);
     });
@@ -499,10 +514,10 @@ function renderSocial(items = []) {
         const div = document.createElement('div');
         div.className = 'social-item';
         div.innerHTML = `
-            <label>Nome: <input type="text" value="${item.name}" data-index="${index}" name="social-name"></label>
-            <label>Link: <input type="text" value="${item.link}" data-index="${index}" name="social-link"></label>
-            <label>Ícone (SVG Path): <input type="text" value="${item.icon}" data-index="${index}" name="social-icon"></label>
-            <button type="button" class="remove-social secondary" data-index="${index}">Remover</button>
+            <button type="button" class="remove-social" data-index="${index}">&times;</button>
+            <label>Nome: <input type="text" value="${item.name}" data-index="${index}" name="social-name" placeholder="Ex.: LinkedIn"></label>
+            <label>Link: <input type="text" value="${item.link}" data-index="${index}" name="social-link" placeholder="https://..."></label>
+            <label>Ícone (SVG Path): <input type="text" value="${item.icon}" data-index="${index}" name="social-icon" placeholder="M12 3..."></label>
         `;
         socialLinks.appendChild(div);
     });
@@ -518,6 +533,10 @@ function openIconPicker(areaIndex) {
         iconOption.addEventListener('click', () => {
             const iconInput = document.querySelector(`input[name="area-icon"][data-index="${currentAreaIndex}"]`);
             iconInput.value = iconPath;
+            const preview = document.querySelector(`.area-icon-preview[data-index="${currentAreaIndex}"]`);
+            if (preview) {
+                preview.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="${iconPath}"/></svg>`;
+            }
             iconPickerModal.style.display = 'none';
         });
         iconPicker.appendChild(iconOption);
@@ -571,6 +590,20 @@ if (contentForm) {
         e.preventDefault();
         const formData = new FormData(contentForm);
         const updatedContent = {
+            site: {
+                title: formData.get('site.title')
+            },
+            nav: {
+                about: formData.get('nav.about'),
+                areas: formData.get('nav.areas'),
+                contact: formData.get('nav.contact'),
+                lawyer: formData.get('nav.lawyer')
+            },
+            sections: {
+                secretary: { title: formData.get('sections.secretary.title') },
+                contact: { title: formData.get('sections.contact.title') },
+                form: { title: formData.get('sections.form.title') }
+            },
             hero: {
                 title: formData.get('hero.title'),
                 subtitle: formData.get('hero.subtitle'),

--- a/public/style.css
+++ b/public/style.css
@@ -961,6 +961,68 @@ input.not-informed {
     box-shadow: 0 0 0 3px rgba(var(--accent), 0.2);
 }
 
+#contentForm details {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 16px;
+  background: rgba(0,0,0,0.15);
+}
+
+#contentForm details:not(:last-of-type) {
+  margin-bottom: 16px;
+}
+
+#contentForm summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin: -16px -16px 16px;
+  padding: 16px;
+  background: rgba(0,0,0,0.25);
+  border-radius: 12px;
+}
+
+#contentForm summary::-webkit-details-marker { display: none; }
+
+#contentForm summary::after {
+  content: '\25BC';
+  float: right;
+  transition: transform 0.2s;
+}
+
+#contentForm details[open] summary::after { transform: rotate(180deg); }
+
+#contentForm .area-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#contentForm .area-icon-preview {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#contentForm .area-icon-preview svg {
+  width: 24px;
+  height: 24px;
+  stroke: var(--text);
+}
+
+#contentForm .icon-placeholder {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: rgba(148, 163, 184, 0.2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--muted);
+}
+
 #contentForm .area-item,
 #contentForm .social-item {
   border: 1px solid rgba(148, 163, 184, 0.2);


### PR DESCRIPTION
## Summary
- adiciona título do site, rótulos de navegação e cabeçalhos de seções ao conteúdo configurável
- expande o editor do advogado para alterar esses novos campos junto com o restante da página
- carrega dinamicamente título, menu e seções no site público a partir do conteúdo salvo

## Testing
- `npm test` *(erro: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae58830b64832d97e3c128f45a9789