### PR TITLE
Improve AI chat with quick replies and remove answer validation

### DIFF
--- a/public/secretary.js
+++ b/public/secretary.js
@@ -56,6 +56,23 @@ document.addEventListener('DOMContentLoaded', () => {
     aiSend.disabled = disabled;
   }
 
+  function appendQuickReplies(options) {
+    const container = document.createElement('div');
+    container.classList.add('chat-message', 'chat-message-assistant', 'quick-replies');
+    options.forEach(opt => {
+      const btn = document.createElement('button');
+      btn.classList.add('question-button');
+      btn.textContent = opt;
+      btn.addEventListener('click', () => {
+        aiInput.value = opt;
+        handleSend();
+      });
+      container.appendChild(btn);
+    });
+    aiMessages.appendChild(container);
+    aiMessages.scrollTop = aiMessages.scrollHeight;
+  }
+
   async function handleInitialMessage() {
     const summary = aiInput.value.trim();
     if (!summary) return;
@@ -272,4 +289,5 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   appendMessage('Olá! Sou a secretária virtual. Por favor, descreva seu caso em poucas palavras para que eu possa ajudar.', 'assistant');
+  appendQuickReplies(['Regularização de Imóveis', 'Direito Trabalhista', 'Direito Empresarial']);
 });

--- a/public/style.css
+++ b/public/style.css
@@ -860,6 +860,16 @@ input.not-informed {
   border-color: var(--accent);
 }
 
+.quick-replies {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  max-width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .checklist-item {
   display: flex;
   align-items: center;

--- a/server.js
+++ b/server.js
@@ -247,30 +247,9 @@ app.post('/api/answers', chatLimiter, async (req, res) => {
     return res.status(400).json({ error: 'missing_api_key' });
   }
   try {
-    const answersText = Object.entries(answers).map(([k, v]) => `- ${intake.questions.find(q => q.id === k)?.text || k}: ${v}`).join('\n');
-
-    // Validação de respostas com IA
-    for (const [key, value] of Object.entries(answers)) {
-      const question = intake.questions.find(q => q.id === key);
-      // Validar apenas campos de texto abertos
-      if (question && (question.type === 'text' || question.type === 'textarea')) {
-        const validationPrompt = `A seguir, uma resposta de um usuário a uma pergunta. A resposta parece sem sentido, evasiva ou um texto aleatório? Responda apenas com 'sim' ou 'não'. Pergunta: "${question.text}" Resposta: "${value}"`;
-        const validationMessages = [{ role: 'user', content: validationPrompt }];
-        const validationResult = await generate(adminConfig.provider, apiKey, validationMessages, { ...adminConfig.parameters, max_output_tokens: 5, temperature: 0.1 });
-
-        if (validationResult.toLowerCase().includes('sim')) {
-          console.log(`Gibberish detected for session ${sessionId}. Answer: ${value}`);
-          const reportText = `O usuário forneceu uma resposta inválida ou sem sentido para a pergunta "${question.text}".\nResposta do usuário: "${value}"\n\nSessão encerrada.`;
-          const newReport = { sessionId, text: reportText, timestamp: Date.now() };
-          reports.push(newReport);
-          if (lawyerSocket) {
-            lawyerSocket.emit('new-report', newReport);
-          }
-          intake.stage = 'done';
-          return res.json({ reply: 'Suas respostas parecem inválidas. A sessão foi encerrada. Um relatório foi enviado ao advogado.' });
-        }
-      }
-    }
+    const answersText = Object.entries(answers)
+      .map(([k, v]) => `- ${intake.questions.find(q => q.id === k)?.text || k}: ${v}`)
+      .join('\n');
 
     let userText;
     // Check if interaction limit is reached


### PR DESCRIPTION
## Summary
- allow AI secretary chat to send quick reply buttons for common topics
- style and wire up quick reply buttons on homepage chat
- remove rigid answer validation that prematurely ended sessions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aefa3f0a20832da41592b1ba7ebcc0