### PR TITLE
Improve homepage AI chat with quick replies

### DIFF
--- a/public/secretary.js
+++ b/public/secretary.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     stage: 'summary' // summary -> questions -> contact -> done
   };
 
-  function appendMessage(text, sender = 'user', type = 'text') {
+  function appendMessage(text, sender = 'user', type = 'text', quickReplies = []) {
     const messageEl = document.createElement('div');
     messageEl.classList.add('chat-message', `chat-message-${sender}`);
 
@@ -28,6 +28,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     aiMessages.appendChild(messageEl);
+
+    if (quickReplies.length > 0) {
+      const btnContainer = document.createElement('div');
+      btnContainer.classList.add('quick-replies');
+      quickReplies.forEach((qr) => {
+        const btn = document.createElement('button');
+        btn.classList.add('quick-reply');
+        btn.textContent = qr.label;
+        btn.addEventListener('click', () => {
+          btnContainer.remove();
+          aiInput.value = qr.value;
+          handleSend();
+        });
+        btnContainer.appendChild(btn);
+      });
+      aiMessages.appendChild(btnContainer);
+    }
+
     aiMessages.scrollTop = aiMessages.scrollHeight;
     return messageEl;
   }
@@ -271,5 +289,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  appendMessage('Olá! Sou a secretária virtual. Por favor, descreva seu caso em poucas palavras para que eu possa ajudar.', 'assistant');
+  appendMessage(
+    'Olá! Sou a secretária virtual. Por favor, descreva seu caso em poucas palavras para que eu possa ajudar.',
+    'assistant',
+    'text',
+    [
+      { label: 'Agendar consulta', value: 'Gostaria de agendar uma consulta.' },
+      { label: 'Falar com advogado', value: 'Preciso falar com um advogado.' },
+      { label: 'Outro assunto', value: 'Tenho outra questão jurídica.' }
+    ]
+  );
 });

--- a/public/style.css
+++ b/public/style.css
@@ -860,6 +860,27 @@ input.not-informed {
   border-color: var(--accent);
 }
 
+.quick-replies {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.quick-reply {
+  background: #334155;
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.quick-reply:hover {
+  background: #475569;
+}
+
 .checklist-item {
   display: flex;
   align-items: center;

--- a/server.js
+++ b/server.js
@@ -249,29 +249,6 @@ app.post('/api/answers', chatLimiter, async (req, res) => {
   try {
     const answersText = Object.entries(answers).map(([k, v]) => `- ${intake.questions.find(q => q.id === k)?.text || k}: ${v}`).join('\n');
 
-    // Validação de respostas com IA
-    for (const [key, value] of Object.entries(answers)) {
-      const question = intake.questions.find(q => q.id === key);
-      // Validar apenas campos de texto abertos
-      if (question && (question.type === 'text' || question.type === 'textarea')) {
-        const validationPrompt = `A seguir, uma resposta de um usuário a uma pergunta. A resposta parece sem sentido, evasiva ou um texto aleatório? Responda apenas com 'sim' ou 'não'. Pergunta: "${question.text}" Resposta: "${value}"`;
-        const validationMessages = [{ role: 'user', content: validationPrompt }];
-        const validationResult = await generate(adminConfig.provider, apiKey, validationMessages, { ...adminConfig.parameters, max_output_tokens: 5, temperature: 0.1 });
-
-        if (validationResult.toLowerCase().includes('sim')) {
-          console.log(`Gibberish detected for session ${sessionId}. Answer: ${value}`);
-          const reportText = `O usuário forneceu uma resposta inválida ou sem sentido para a pergunta "${question.text}".\nResposta do usuário: "${value}"\n\nSessão encerrada.`;
-          const newReport = { sessionId, text: reportText, timestamp: Date.now() };
-          reports.push(newReport);
-          if (lawyerSocket) {
-            lawyerSocket.emit('new-report', newReport);
-          }
-          intake.stage = 'done';
-          return res.json({ reply: 'Suas respostas parecem inválidas. A sessão foi encerrada. Um relatório foi enviado ao advogado.' });
-        }
-      }
-    }
-
     let userText;
     // Check if interaction limit is reached
     if (intake.interactionCount >= 3) {


### PR DESCRIPTION
## Summary
- Allow secretary chat to render quick reply buttons and handle their clicks
- Style quick reply buttons within chat interface
- Remove server-side logic that ended chat sessions on unclear answers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aefc7a0aa0832d887cd3f1511ee798