### PR TITLE
Fix chat scroll overflow and update header navigation

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,16 +19,16 @@ const Header: React.FC = () => {
       <a href="#services" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">Servicos</a>
       <a href="#team" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">O Fundador</a>
       <a href="#testimonials" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">Clientes</a>
-      <a
-        href="#contact"
-        onClick={closeMenu}
-        className="mt-4 md:mt-0 md:ml-4 px-4 py-2 border border-white rounded-sm hover:bg-white hover:text-[#0D1B2A] transition-colors font-bold"
-      >
-        CONTATO
-      </a>
       <Link to="/lawyer" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">
         Area do Advogado
       </Link>
+      <a
+        href="#contact"
+        onClick={closeMenu}
+        className="mt-4 md:mt-0 md:ml-4 px-4 py-2 border border-white rounded-sm hover:bg-white hover:text-[#0D1B2A] transition-colors font-bold inline-flex items-center justify-center md:-translate-y-0.5"
+      >
+        CONTATO
+      </a>
     </>
   );
 

--- a/styles/floating-chat.css
+++ b/styles/floating-chat.css
@@ -46,6 +46,10 @@
   transform: translateY(0);
 }
 
+.chat-window .card-body {
+  min-height: 0;
+}
+
 .chat-scrollable {
   flex-grow: 1;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- allow the floating chat content area to scroll by giving the card body a min-height of zero
- move the "Área do Advogado" link immediately before the contact button in the header navigation
- align the contact button with the rest of the menu items using flex centering and a slight upward translation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf652da38832daa1e46582c1f6078