### PR TITLE
Fix chat scrolling and adjust header buttons

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,16 +19,16 @@ const Header: React.FC = () => {
       <a href="#services" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">Servicos</a>
       <a href="#team" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">O Fundador</a>
       <a href="#testimonials" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">Clientes</a>
-      <a
-        href="#contact"
-        onClick={closeMenu}
-        className="mt-4 md:mt-0 md:ml-4 px-4 py-2 border border-white rounded-sm hover:bg-white hover:text-[#0D1B2A] transition-colors font-bold"
-      >
-        CONTATO
-      </a>
       <Link to="/lawyer" onClick={closeMenu} className="hover:text-[#B98F58] transition-colors font-medium">
         Area do Advogado
       </Link>
+      <a
+        href="#contact"
+        onClick={closeMenu}
+        className="mt-4 md:mt-0 md:-translate-y-1 md:ml-4 inline-flex items-center justify-center px-4 py-2 border border-white rounded-sm hover:bg-white hover:text-[#0D1B2A] transition-colors font-bold"
+      >
+        CONTATO
+      </a>
     </>
   );
 

--- a/styles/floating-chat.css
+++ b/styles/floating-chat.css
@@ -46,8 +46,14 @@
   transform: translateY(0);
 }
 
+.chat-window .card-body {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .chat-scrollable {
   flex-grow: 1;
+  min-height: 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure the floating chat window body can shrink and scroll properly so long conversations stay accessible
- reorder the lawyer area link ahead of the contact button and tweak the button alignment for desktop navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf652da38832daa1e46582c1f6078